### PR TITLE
Remove index configuration from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
--i https://pypi.python.org/simple
 thoth-common
 faust


### PR DESCRIPTION
```
error in thoth-messaging setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Invalid requirement, parse error at "'-i'"
```