### PR TITLE
revert the release of v0.5.0 and v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog for Thoth's Template GitHub Project
+# Changelog for Thoth's Messaging GitHub Project
 
 ## [0.2.0] - 2019-Oct-05 - goern
 
@@ -13,454 +13,167 @@ Added methods to create a topic and to send to a topic. These need some love, er
 all the things that you see...
 
 ## Release 0.2.1 (2019-10-08T08:08:16)
-* :pushpin: Automatic update of dependency pytest-cov from 2.7.1 to 2.8.1
-* :pushpin: Automatic update of dependency pytest from 5.1.3 to 5.2.1
-* :pushpin: Automatic update of dependency faust from 1.7.4 to 1.8.0
-* :pushpin: Automatic update of dependency thoth-common from 0.9.10 to 0.9.12
-* Update .zuul.yaml
-* :green_heart: removed the pytest jobs from all pipelines
-* :green_heart: started adding tests
-* :green_heart: added the tests/ directory
-* :green_heart: remove the writing of test coverage data (for now)
-* oh, left over stuff we dont need was removed
-* added a release pipeline job to push to pypi
-* :sparkles: added create_topic, publish_to_topic
-* added the required requirements files
-* note required
-* added an explicite serializer
-* this is the basic set of files, updated ...
+
+- :pushpin: Automatic update of dependency pytest-cov from 2.7.1 to 2.8.1
+- :pushpin: Automatic update of dependency pytest from 5.1.3 to 5.2.1
+- :pushpin: Automatic update of dependency faust from 1.7.4 to 1.8.0
+- :pushpin: Automatic update of dependency thoth-common from 0.9.10 to 0.9.12
+- Update .zuul.yaml
+- :green_heart: removed the pytest jobs from all pipelines
+- :green_heart: started adding tests
+- :green_heart: added the tests/ directory
+- :green_heart: remove the writing of test coverage data (for now)
+- oh, left over stuff we dont need was removed
+- added a release pipeline job to push to pypi
+- :sparkles: added create_topic, publish_to_topic
+- added the required requirements files
+- note required
+- added an explicite serializer
+- this is the basic set of files, updated ...
 
 ## Release 0.3.0 (2020-02-04T01:34:39)
-* :pushpin: Automatic update of dependency thoth-common from 0.10.1 to 0.10.2
-* :pushpin: Automatic update of dependency thoth-common from 0.10.0 to 0.10.1
-* :pushpin: Automatic update of dependency pytest from 5.3.4 to 5.3.5
-* :pushpin: Automatic update of dependency thoth-common from 0.9.31 to 0.10.0
-* :pushpin: Automatic update of dependency thoth-common from 0.9.30 to 0.9.31
-* :pushpin: Automatic update of dependency thoth-common from 0.9.29 to 0.9.30
-* :pushpin: Automatic update of dependency faust from 1.10.0 to 1.10.1
-* :pushpin: Automatic update of dependency pytest from 5.3.3 to 5.3.4
-* :pushpin: Automatic update of dependency thoth-common from 0.9.28 to 0.9.29
-* :pushpin: Automatic update of dependency pytest from 5.3.2 to 5.3.3
-* :pushpin: Automatic update of dependency thoth-common from 0.9.27 to 0.9.28
-* :pushpin: Automatic update of dependency thoth-common from 0.9.26 to 0.9.27
-* :pushpin: Automatic update of dependency thoth-common from 0.9.25 to 0.9.26
-* :pushpin: Automatic update of dependency faust from 1.9.0 to 1.10.0
-* :pushpin: Automatic update of dependency thoth-common from 0.9.24 to 0.9.25
-* :pushpin: Automatic update of dependency thoth-common from 0.9.23 to 0.9.24
-* :pushpin: Automatic update of dependency thoth-common from 0.9.22 to 0.9.23
-* :pushpin: Automatic update of dependency pytest-timeout from 1.3.3 to 1.3.4
-* Happy new year!
-* :pushpin: Automatic update of dependency pytest from 5.3.1 to 5.3.2
-* :pushpin: Automatic update of dependency thoth-common from 0.9.21 to 0.9.22
-* :pushpin: Automatic update of dependency thoth-common from 0.9.20 to 0.9.21
-* :pushpin: Automatic update of dependency thoth-common from 0.9.19 to 0.9.20
-* :pushpin: Automatic update of dependency thoth-common from 0.9.18 to 0.9.19
-* :pushpin: Automatic update of dependency thoth-common from 0.9.17 to 0.9.18
-* :pushpin: Automatic update of dependency thoth-common from 0.9.16 to 0.9.17
-* :pushpin: Automatic update of dependency pytest from 5.3.0 to 5.3.1
-* :pushpin: Automatic update of dependency pytest from 5.2.4 to 5.3.0
-* :pushpin: Automatic update of dependency pytest from 5.2.3 to 5.2.4
-* :pushpin: Automatic update of dependency pytest from 5.2.2 to 5.2.3
-* :pushpin: Automatic update of dependency thoth-common from 0.9.15 to 0.9.16
-* :pushpin: Automatic update of dependency thoth-common from 0.9.14 to 0.9.15
-* :pushpin: Automatic update of dependency faust from 1.8.1 to 1.9.0
-* :pushpin: Automatic update of dependency black from 19.3b0 to 19.10b0
-* :pushpin: Automatic update of dependency pytest from 5.2.1 to 5.2.2
-* :pushpin: Automatic update of dependency faust from 1.8.0 to 1.8.1
-* :pushpin: Automatic update of dependency thoth-common from 0.9.12 to 0.9.14
+
+- :pushpin: Automatic update of dependency thoth-common from 0.10.1 to 0.10.2
+- :pushpin: Automatic update of dependency thoth-common from 0.10.0 to 0.10.1
+- :pushpin: Automatic update of dependency pytest from 5.3.4 to 5.3.5
+- :pushpin: Automatic update of dependency thoth-common from 0.9.31 to 0.10.0
+- :pushpin: Automatic update of dependency thoth-common from 0.9.30 to 0.9.31
+- :pushpin: Automatic update of dependency thoth-common from 0.9.29 to 0.9.30
+- :pushpin: Automatic update of dependency faust from 1.10.0 to 1.10.1
+- :pushpin: Automatic update of dependency pytest from 5.3.3 to 5.3.4
+- :pushpin: Automatic update of dependency thoth-common from 0.9.28 to 0.9.29
+- :pushpin: Automatic update of dependency pytest from 5.3.2 to 5.3.3
+- :pushpin: Automatic update of dependency thoth-common from 0.9.27 to 0.9.28
+- :pushpin: Automatic update of dependency thoth-common from 0.9.26 to 0.9.27
+- :pushpin: Automatic update of dependency thoth-common from 0.9.25 to 0.9.26
+- :pushpin: Automatic update of dependency faust from 1.9.0 to 1.10.0
+- :pushpin: Automatic update of dependency thoth-common from 0.9.24 to 0.9.25
+- :pushpin: Automatic update of dependency thoth-common from 0.9.23 to 0.9.24
+- :pushpin: Automatic update of dependency thoth-common from 0.9.22 to 0.9.23
+- :pushpin: Automatic update of dependency pytest-timeout from 1.3.3 to 1.3.4
+- Happy new year!
+- :pushpin: Automatic update of dependency pytest from 5.3.1 to 5.3.2
+- :pushpin: Automatic update of dependency thoth-common from 0.9.21 to 0.9.22
+- :pushpin: Automatic update of dependency thoth-common from 0.9.20 to 0.9.21
+- :pushpin: Automatic update of dependency thoth-common from 0.9.19 to 0.9.20
+- :pushpin: Automatic update of dependency thoth-common from 0.9.18 to 0.9.19
+- :pushpin: Automatic update of dependency thoth-common from 0.9.17 to 0.9.18
+- :pushpin: Automatic update of dependency thoth-common from 0.9.16 to 0.9.17
+- :pushpin: Automatic update of dependency pytest from 5.3.0 to 5.3.1
+- :pushpin: Automatic update of dependency pytest from 5.2.4 to 5.3.0
+- :pushpin: Automatic update of dependency pytest from 5.2.3 to 5.2.4
+- :pushpin: Automatic update of dependency pytest from 5.2.2 to 5.2.3
+- :pushpin: Automatic update of dependency thoth-common from 0.9.15 to 0.9.16
+- :pushpin: Automatic update of dependency thoth-common from 0.9.14 to 0.9.15
+- :pushpin: Automatic update of dependency faust from 1.8.1 to 1.9.0
+- :pushpin: Automatic update of dependency black from 19.3b0 to 19.10b0
+- :pushpin: Automatic update of dependency pytest from 5.2.1 to 5.2.2
+- :pushpin: Automatic update of dependency faust from 1.8.0 to 1.8.1
+- :pushpin: Automatic update of dependency thoth-common from 0.9.12 to 0.9.14
 
 ## Release 0.3.1 (2020-02-13T20:30:25)
-* relocked
-* relocked
-* :pushpin: Automatic update of dependency thoth-common from 0.10.5 to 0.10.6
-* :pushpin: Automatic update of dependency faust from 1.10.1 to 1.10.2
-* Update .thoth.yaml
-* :pushpin: Automatic update of dependency thoth-common from 0.10.4 to 0.10.5
-* :pushpin: Automatic update of dependency thoth-common from 0.10.3 to 0.10.4
-* :pushpin: Automatic update of dependency thoth-common from 0.10.2 to 0.10.3
+
+- relocked
+- relocked
+- :pushpin: Automatic update of dependency thoth-common from 0.10.5 to 0.10.6
+- :pushpin: Automatic update of dependency faust from 1.10.1 to 1.10.2
+- Update .thoth.yaml
+- :pushpin: Automatic update of dependency thoth-common from 0.10.4 to 0.10.5
+- :pushpin: Automatic update of dependency thoth-common from 0.10.3 to 0.10.4
+- :pushpin: Automatic update of dependency thoth-common from 0.10.2 to 0.10.3
 
 ## Release 0.3.2 (2020-02-13T22:08:54)
-* updated github templates
-* relocked
+
+- updated github templates
+- relocked
 
 ## Release 0.3.3 (2020-03-30T15:14:47)
-* List is not needed for advise_justification
-* add advise_justification to init
-* coala styling, missing new line
-* Adjust requirements not to lock sub-dependencies
-* Remove prereleases
-* :pushpin: Automatic update of dependency thoth-common from 0.12.3 to 0.12.4
-* import typing
-* remove logging
-* reorder __init__
-* import faust in messages
-* Add advise message and some details in doc strings
-* :pushpin: Automatic update of dependency thoth-common from 0.12.2 to 0.12.3
-* :pushpin: Automatic update of dependency thoth-common from 0.12.1 to 0.12.2
-* follow standard naming convention
-* :pushpin: Automatic update of dependency thoth-common from 0.12.0 to 0.12.1
-* :pushpin: Automatic update of dependency thoth-common from 0.10.12 to 0.12.0
-* Remove unnecessary imports
-* Add messaging to messaging module
-* :pushpin: Automatic update of dependency thoth-common from 0.10.11 to 0.10.12
-* :pushpin: Automatic update of dependency pytest from 5.4.0 to 5.4.1
-* :pushpin: Automatic update of dependency pytest from 5.3.5 to 5.4.0
-* :pushpin: Automatic update of dependency thoth-common from 0.10.9 to 0.10.11
-* :pushpin: Automatic update of dependency thoth-common from 0.10.9 to 0.10.11
-* :pushpin: Automatic update of dependency thoth-common from 0.10.8 to 0.10.9
-* :pushpin: Automatic update of dependency faust from 1.10.3 to 1.10.4
-* :pushpin: Automatic update of dependency thoth-common from 0.10.7 to 0.10.8
-* :pushpin: Automatic update of dependency faust from 1.10.2 to 1.10.3
-* :pushpin: Automatic update of dependency thoth-common from 0.10.6 to 0.10.7
+
+- List is not needed for advise_justification
+- add advise_justification to init
+- coala styling, missing new line
+- Adjust requirements not to lock sub-dependencies
+- Remove prereleases
+- :pushpin: Automatic update of dependency thoth-common from 0.12.3 to 0.12.4
+- import typing
+- remove logging
+- reorder **init**
+- import faust in messages
+- Add advise message and some details in doc strings
+- :pushpin: Automatic update of dependency thoth-common from 0.12.2 to 0.12.3
+- :pushpin: Automatic update of dependency thoth-common from 0.12.1 to 0.12.2
+- follow standard naming convention
+- :pushpin: Automatic update of dependency thoth-common from 0.12.0 to 0.12.1
+- :pushpin: Automatic update of dependency thoth-common from 0.10.12 to 0.12.0
+- Remove unnecessary imports
+- Add messaging to messaging module
+- :pushpin: Automatic update of dependency thoth-common from 0.10.11 to 0.10.12
+- :pushpin: Automatic update of dependency pytest from 5.4.0 to 5.4.1
+- :pushpin: Automatic update of dependency pytest from 5.3.5 to 5.4.0
+- :pushpin: Automatic update of dependency thoth-common from 0.10.9 to 0.10.11
+- :pushpin: Automatic update of dependency thoth-common from 0.10.9 to 0.10.11
+- :pushpin: Automatic update of dependency thoth-common from 0.10.8 to 0.10.9
+- :pushpin: Automatic update of dependency faust from 1.10.3 to 1.10.4
+- :pushpin: Automatic update of dependency thoth-common from 0.10.7 to 0.10.8
+- :pushpin: Automatic update of dependency faust from 1.10.2 to 1.10.3
+- :pushpin: Automatic update of dependency thoth-common from 0.10.6 to 0.10.7
 
 ## Release 0.3.4 (2020-03-31T14:45:47)
-* Remove index configuration from requirements.txt
+
+- Remove index configuration from requirements.txt
 
 ## Release 0.3.5 (2020-05-06T09:03:49)
-* Correct docstring
-* Remove coala-bears
-* Add unresolved package message
-* :pushpin: Automatic dependency re-locking
-* :pushpin: Automatic update of dependency thoth-common from 0.13.1 to 0.13.2
-* :pushpin: Automatic update of dependency thoth-common from 0.13.0 to 0.13.1
-* :pushpin: Automatic update of dependency thoth-common from 0.12.10 to 0.13.0
-* :pushpin: Automatic update of dependency thoth-common from 0.12.9 to 0.12.10
-* :pushpin: Automatic update of dependency thoth-common from 0.12.8 to 0.12.9
-* :pushpin: Automatic update of dependency thoth-common from 0.12.7 to 0.12.8
-* :pushpin: Automatic update of dependency thoth-common from 0.12.6 to 0.12.7
-* get kafka_client_id from env variable
-* Add env option for disabling SSL
-* :pushpin: Automatic update of dependency thoth-common from 0.12.5 to 0.12.6
-* :pushpin: Automatic update of dependency thoth-common from 0.12.4 to 0.12.5
+
+- Correct docstring
+- Remove coala-bears
+- Add unresolved package message
+- :pushpin: Automatic dependency re-locking
+- :pushpin: Automatic update of dependency thoth-common from 0.13.1 to 0.13.2
+- :pushpin: Automatic update of dependency thoth-common from 0.13.0 to 0.13.1
+- :pushpin: Automatic update of dependency thoth-common from 0.12.10 to 0.13.0
+- :pushpin: Automatic update of dependency thoth-common from 0.12.9 to 0.12.10
+- :pushpin: Automatic update of dependency thoth-common from 0.12.8 to 0.12.9
+- :pushpin: Automatic update of dependency thoth-common from 0.12.7 to 0.12.8
+- :pushpin: Automatic update of dependency thoth-common from 0.12.6 to 0.12.7
+- get kafka_client_id from env variable
+- Add env option for disabling SSL
+- :pushpin: Automatic update of dependency thoth-common from 0.12.5 to 0.12.6
+- :pushpin: Automatic update of dependency thoth-common from 0.12.4 to 0.12.5
 
 ## Release 0.3.6 (2020-05-11T17:31:38)
-* Adjust typing
-* Use solver
-* :pushpin: Automatic update of dependency pytest from 5.4.1 to 5.4.2
-* add message factory to readme
-* Update info strings
-* coala styling
-* Allow users to using python std lib typing
-* Create simple message factory
+
+- Adjust typing
+- Use solver
+- :pushpin: Automatic update of dependency pytest from 5.4.1 to 5.4.2
+- add message factory to readme
+- Update info strings
+- coala styling
+- Allow users to using python std lib typing
+- Create simple message factory
 
 ## Release 0.3.7 (2020-07-09T17:59:02)
-* Add maintainer (#156)
-* :pushpin: Automatic update of dependency pylint from 2.5.2 to 2.5.3 (#154)
-* :pushpin: Automatic update of dependency pylint from 2.5.2 to 2.5.3 (#152)
-* :pushpin: Automatic update of dependency pytest-cov from 2.9.0 to 2.10.0 (#151)
-* :pushpin: Automatic update of dependency pytest-cov from 2.9.0 to 2.10.0 (#150)
-* :pushpin: Automatic update of dependency pytest-timeout from 1.3.4 to 1.4.1 (#149)
-* :pushpin: Automatic update of dependency pytest-timeout from 1.3.4 to 1.4.1 (#148)
-* :pushpin: Automatic update of dependency thoth-common from 0.13.8 to 0.14.1 (#147)
-* :pushpin: Automatic update of dependency thoth-common from 0.13.8 to 0.14.1 (#146)
-* Add missing import to use the class (#144)
-* Create OWNERS
-* :pushpin: Automatic update of dependency pytest from 5.4.2 to 5.4.3
-* :pushpin: Automatic update of dependency thoth-common from 0.13.7 to 0.13.8
-* :pushpin: Automatic update of dependency thoth-common from 0.13.6 to 0.13.7
-* :pushpin: Automatic update of dependency pytest-cov from 2.8.1 to 2.9.0
-* :pushpin: Automatic update of dependency thoth-common from 0.13.5 to 0.13.6
-* :pushpin: Automatic update of dependency thoth-common from 0.13.4 to 0.13.5
-* :pushpin: Automatic update of dependency thoth-common from 0.13.3 to 0.13.4
+
+- Add maintainer (#156)
+- :pushpin: Automatic update of dependency pylint from 2.5.2 to 2.5.3 (#154)
+- :pushpin: Automatic update of dependency pylint from 2.5.2 to 2.5.3 (#152)
+- :pushpin: Automatic update of dependency pytest-cov from 2.9.0 to 2.10.0 (#151)
+- :pushpin: Automatic update of dependency pytest-cov from 2.9.0 to 2.10.0 (#150)
+- :pushpin: Automatic update of dependency pytest-timeout from 1.3.4 to 1.4.1 (#149)
+- :pushpin: Automatic update of dependency pytest-timeout from 1.3.4 to 1.4.1 (#148)
+- :pushpin: Automatic update of dependency thoth-common from 0.13.8 to 0.14.1 (#147)
+- :pushpin: Automatic update of dependency thoth-common from 0.13.8 to 0.14.1 (#146)
+- Add missing import to use the class (#144)
+- Create OWNERS
+- :pushpin: Automatic update of dependency pytest from 5.4.2 to 5.4.3
+- :pushpin: Automatic update of dependency thoth-common from 0.13.7 to 0.13.8
+- :pushpin: Automatic update of dependency thoth-common from 0.13.6 to 0.13.7
+- :pushpin: Automatic update of dependency pytest-cov from 2.8.1 to 2.9.0
+- :pushpin: Automatic update of dependency thoth-common from 0.13.5 to 0.13.6
+- :pushpin: Automatic update of dependency thoth-common from 0.13.4 to 0.13.5
+- :pushpin: Automatic update of dependency thoth-common from 0.13.3 to 0.13.4
 
 ## Release 0.4.0 (2020-07-16T17:20:56)
-* :pushpin: Automatic update of dependency pytest-timeout from 1.4.1 to 1.4.2 (#164)
-* Modify class not be initialized during import (#160)
-* Adjust message specs (#162)
 
-## Release 0.5.0 (2020-07-17T13:32:22)
-* Release of version 0.4.0 (#166)
-* :pushpin: Automatic update of dependency pytest-timeout from 1.4.1 to 1.4.2 (#164)
-* Modify class not be initialized during import (#160)
-* Adjust message specs (#162)
-* Release of version 0.3.7 (#159)
-* Add maintainer (#156)
-* :pushpin: Automatic update of dependency pylint from 2.5.2 to 2.5.3 (#154)
-* :pushpin: Automatic update of dependency pylint from 2.5.2 to 2.5.3 (#152)
-* :pushpin: Automatic update of dependency pytest-cov from 2.9.0 to 2.10.0 (#151)
-* :pushpin: Automatic update of dependency pytest-cov from 2.9.0 to 2.10.0 (#150)
-* :pushpin: Automatic update of dependency pytest-timeout from 1.3.4 to 1.4.1 (#149)
-* :pushpin: Automatic update of dependency pytest-timeout from 1.3.4 to 1.4.1 (#148)
-* :pushpin: Automatic update of dependency thoth-common from 0.13.8 to 0.14.1 (#147)
-* :pushpin: Automatic update of dependency thoth-common from 0.13.8 to 0.14.1 (#146)
-* Add missing import to use the class (#144)
-* Create OWNERS
-* :pushpin: Automatic update of dependency pytest from 5.4.2 to 5.4.3
-* :pushpin: Automatic update of dependency thoth-common from 0.13.7 to 0.13.8
-* :pushpin: Automatic update of dependency thoth-common from 0.13.6 to 0.13.7
-* :pushpin: Automatic update of dependency pytest-cov from 2.8.1 to 2.9.0
-* :pushpin: Automatic update of dependency thoth-common from 0.13.5 to 0.13.6
-* :pushpin: Automatic update of dependency thoth-common from 0.13.4 to 0.13.5
-* :pushpin: Automatic update of dependency thoth-common from 0.13.3 to 0.13.4
-* Release of version 0.3.6
-* Adjust typing
-* Use solver
-* :pushpin: Automatic update of dependency pytest from 5.4.1 to 5.4.2
-* Release of version 0.3.5
-* Correct docstring
-* Remove coala-bears
-* Add unresolved package message
-* :pushpin: Automatic dependency re-locking
-* :pushpin: Automatic update of dependency thoth-common from 0.13.1 to 0.13.2
-* :pushpin: Automatic update of dependency thoth-common from 0.13.0 to 0.13.1
-* :pushpin: Automatic update of dependency thoth-common from 0.12.10 to 0.13.0
-* :pushpin: Automatic update of dependency thoth-common from 0.12.9 to 0.12.10
-* :pushpin: Automatic update of dependency thoth-common from 0.12.8 to 0.12.9
-* :pushpin: Automatic update of dependency thoth-common from 0.12.7 to 0.12.8
-* :pushpin: Automatic update of dependency thoth-common from 0.12.6 to 0.12.7
-* get kafka_client_id from env variable
-* Add env option for disabling SSL
-* :pushpin: Automatic update of dependency thoth-common from 0.12.5 to 0.12.6
-* add message factory to readme
-* Update info strings
-* :pushpin: Automatic update of dependency thoth-common from 0.12.4 to 0.12.5
-* coala styling
-* Allow users to using python std lib typing
-* Create simple message factory
-* Release of version 0.3.4
-* Remove index configuration from requirements.txt
-* Release of version 0.3.3
-* List is not needed for advise_justification
-* add advise_justification to init
-* coala styling, missing new line
-* Adjust requirements not to lock sub-dependencies
-* Remove prereleases
-* :pushpin: Automatic update of dependency thoth-common from 0.12.3 to 0.12.4
-* import typing
-* remove logging
-* reorder __init__
-* import faust in messages
-* Add advise message and some details in doc strings
-* :pushpin: Automatic update of dependency thoth-common from 0.12.2 to 0.12.3
-* :pushpin: Automatic update of dependency thoth-common from 0.12.1 to 0.12.2
-* follow standard naming convention
-* :pushpin: Automatic update of dependency thoth-common from 0.12.0 to 0.12.1
-* :pushpin: Automatic update of dependency thoth-common from 0.10.12 to 0.12.0
-* Remove unnecessary imports
-* Add messaging to messaging module
-* :pushpin: Automatic update of dependency thoth-common from 0.10.11 to 0.10.12
-* :pushpin: Automatic update of dependency pytest from 5.4.0 to 5.4.1
-* :pushpin: Automatic update of dependency pytest from 5.3.5 to 5.4.0
-* :pushpin: Automatic update of dependency thoth-common from 0.10.9 to 0.10.11
-* :pushpin: Automatic update of dependency thoth-common from 0.10.9 to 0.10.11
-* :pushpin: Automatic update of dependency thoth-common from 0.10.8 to 0.10.9
-* :pushpin: Automatic update of dependency faust from 1.10.3 to 1.10.4
-* :pushpin: Automatic update of dependency thoth-common from 0.10.7 to 0.10.8
-* :pushpin: Automatic update of dependency faust from 1.10.2 to 1.10.3
-* :pushpin: Automatic update of dependency thoth-common from 0.10.6 to 0.10.7
-* Release of version 0.3.2
-* updated github templates
-* relocked
-* Release of version 0.3.1
-* relocked
-* relocked
-* :pushpin: Automatic update of dependency thoth-common from 0.10.5 to 0.10.6
-* :pushpin: Automatic update of dependency faust from 1.10.1 to 1.10.2
-* Update .thoth.yaml
-* :pushpin: Automatic update of dependency thoth-common from 0.10.4 to 0.10.5
-* :pushpin: Automatic update of dependency thoth-common from 0.10.3 to 0.10.4
-* :pushpin: Automatic update of dependency thoth-common from 0.10.2 to 0.10.3
-* Release of version 0.3.0
-* :pushpin: Automatic update of dependency thoth-common from 0.10.1 to 0.10.2
-* :pushpin: Automatic update of dependency thoth-common from 0.10.0 to 0.10.1
-* :pushpin: Automatic update of dependency pytest from 5.3.4 to 5.3.5
-* :pushpin: Automatic update of dependency thoth-common from 0.9.31 to 0.10.0
-* :pushpin: Automatic update of dependency thoth-common from 0.9.30 to 0.9.31
-* :pushpin: Automatic update of dependency thoth-common from 0.9.29 to 0.9.30
-* :pushpin: Automatic update of dependency faust from 1.10.0 to 1.10.1
-* :pushpin: Automatic update of dependency pytest from 5.3.3 to 5.3.4
-* :pushpin: Automatic update of dependency thoth-common from 0.9.28 to 0.9.29
-* :pushpin: Automatic update of dependency pytest from 5.3.2 to 5.3.3
-* :pushpin: Automatic update of dependency thoth-common from 0.9.27 to 0.9.28
-* :pushpin: Automatic update of dependency thoth-common from 0.9.26 to 0.9.27
-* :pushpin: Automatic update of dependency thoth-common from 0.9.25 to 0.9.26
-* :pushpin: Automatic update of dependency faust from 1.9.0 to 1.10.0
-* :pushpin: Automatic update of dependency thoth-common from 0.9.24 to 0.9.25
-* :pushpin: Automatic update of dependency thoth-common from 0.9.23 to 0.9.24
-* :pushpin: Automatic update of dependency thoth-common from 0.9.22 to 0.9.23
-* :pushpin: Automatic update of dependency pytest-timeout from 1.3.3 to 1.3.4
-* Happy new year!
-* :pushpin: Automatic update of dependency pytest from 5.3.1 to 5.3.2
-* :pushpin: Automatic update of dependency thoth-common from 0.9.21 to 0.9.22
-* :pushpin: Automatic update of dependency thoth-common from 0.9.20 to 0.9.21
-* :pushpin: Automatic update of dependency thoth-common from 0.9.19 to 0.9.20
-* :pushpin: Automatic update of dependency thoth-common from 0.9.18 to 0.9.19
-* :pushpin: Automatic update of dependency thoth-common from 0.9.17 to 0.9.18
-* :pushpin: Automatic update of dependency thoth-common from 0.9.16 to 0.9.17
-* :pushpin: Automatic update of dependency pytest from 5.3.0 to 5.3.1
-* :pushpin: Automatic update of dependency pytest from 5.2.4 to 5.3.0
-* :pushpin: Automatic update of dependency pytest from 5.2.3 to 5.2.4
-* :pushpin: Automatic update of dependency pytest from 5.2.2 to 5.2.3
-* :pushpin: Automatic update of dependency thoth-common from 0.9.15 to 0.9.16
-* :pushpin: Automatic update of dependency thoth-common from 0.9.14 to 0.9.15
-* :pushpin: Automatic update of dependency faust from 1.8.1 to 1.9.0
-* :pushpin: Automatic update of dependency black from 19.3b0 to 19.10b0
-* :pushpin: Automatic update of dependency pytest from 5.2.1 to 5.2.2
-* :pushpin: Automatic update of dependency faust from 1.8.0 to 1.8.1
-* :pushpin: Automatic update of dependency thoth-common from 0.9.12 to 0.9.14
-* Release of version 0.2.1
-* :pushpin: Automatic update of dependency pytest-cov from 2.7.1 to 2.8.1
-* :pushpin: Automatic update of dependency pytest from 5.1.3 to 5.2.1
-* :pushpin: Automatic update of dependency faust from 1.7.4 to 1.8.0
-* :pushpin: Automatic update of dependency thoth-common from 0.9.10 to 0.9.12
-* Update .zuul.yaml
-* :green_heart: removed the pytest jobs from all pipelines
-* :green_heart: started adding tests
-* :green_heart: added the tests/ directory
-* :green_heart: remove the writing of test coverage data (for now)
-* oh, left over stuff we dont need was removed
-* added a release pipeline job to push to pypi
-* :sparkles: added create_topic, publish_to_topic
-* added the required requirements files
-* note required
-* added an explicite serializer
-* this is the basic set of files, updated ...
-
-## Release 0.6.0 (2020-07-20T07:36:56)
-* Release of version 0.5.0 (#168)
-* Release of version 0.4.0 (#166)
-* :pushpin: Automatic update of dependency pytest-timeout from 1.4.1 to 1.4.2 (#164)
-* Modify class not be initialized during import (#160)
-* Adjust message specs (#162)
-* Release of version 0.3.7 (#159)
-* Add maintainer (#156)
-* :pushpin: Automatic update of dependency pylint from 2.5.2 to 2.5.3 (#154)
-* :pushpin: Automatic update of dependency pylint from 2.5.2 to 2.5.3 (#152)
-* :pushpin: Automatic update of dependency pytest-cov from 2.9.0 to 2.10.0 (#151)
-* :pushpin: Automatic update of dependency pytest-cov from 2.9.0 to 2.10.0 (#150)
-* :pushpin: Automatic update of dependency pytest-timeout from 1.3.4 to 1.4.1 (#149)
-* :pushpin: Automatic update of dependency pytest-timeout from 1.3.4 to 1.4.1 (#148)
-* :pushpin: Automatic update of dependency thoth-common from 0.13.8 to 0.14.1 (#147)
-* :pushpin: Automatic update of dependency thoth-common from 0.13.8 to 0.14.1 (#146)
-* Add missing import to use the class (#144)
-* Create OWNERS
-* :pushpin: Automatic update of dependency pytest from 5.4.2 to 5.4.3
-* :pushpin: Automatic update of dependency thoth-common from 0.13.7 to 0.13.8
-* :pushpin: Automatic update of dependency thoth-common from 0.13.6 to 0.13.7
-* :pushpin: Automatic update of dependency pytest-cov from 2.8.1 to 2.9.0
-* :pushpin: Automatic update of dependency thoth-common from 0.13.5 to 0.13.6
-* :pushpin: Automatic update of dependency thoth-common from 0.13.4 to 0.13.5
-* :pushpin: Automatic update of dependency thoth-common from 0.13.3 to 0.13.4
-* Release of version 0.3.6
-* Adjust typing
-* Use solver
-* :pushpin: Automatic update of dependency pytest from 5.4.1 to 5.4.2
-* Release of version 0.3.5
-* Correct docstring
-* Remove coala-bears
-* Add unresolved package message
-* :pushpin: Automatic dependency re-locking
-* :pushpin: Automatic update of dependency thoth-common from 0.13.1 to 0.13.2
-* :pushpin: Automatic update of dependency thoth-common from 0.13.0 to 0.13.1
-* :pushpin: Automatic update of dependency thoth-common from 0.12.10 to 0.13.0
-* :pushpin: Automatic update of dependency thoth-common from 0.12.9 to 0.12.10
-* :pushpin: Automatic update of dependency thoth-common from 0.12.8 to 0.12.9
-* :pushpin: Automatic update of dependency thoth-common from 0.12.7 to 0.12.8
-* :pushpin: Automatic update of dependency thoth-common from 0.12.6 to 0.12.7
-* get kafka_client_id from env variable
-* Add env option for disabling SSL
-* :pushpin: Automatic update of dependency thoth-common from 0.12.5 to 0.12.6
-* add message factory to readme
-* Update info strings
-* :pushpin: Automatic update of dependency thoth-common from 0.12.4 to 0.12.5
-* coala styling
-* Allow users to using python std lib typing
-* Create simple message factory
-* Release of version 0.3.4
-* Remove index configuration from requirements.txt
-* Release of version 0.3.3
-* List is not needed for advise_justification
-* add advise_justification to init
-* coala styling, missing new line
-* Adjust requirements not to lock sub-dependencies
-* Remove prereleases
-* :pushpin: Automatic update of dependency thoth-common from 0.12.3 to 0.12.4
-* import typing
-* remove logging
-* reorder __init__
-* import faust in messages
-* Add advise message and some details in doc strings
-* :pushpin: Automatic update of dependency thoth-common from 0.12.2 to 0.12.3
-* :pushpin: Automatic update of dependency thoth-common from 0.12.1 to 0.12.2
-* follow standard naming convention
-* :pushpin: Automatic update of dependency thoth-common from 0.12.0 to 0.12.1
-* :pushpin: Automatic update of dependency thoth-common from 0.10.12 to 0.12.0
-* Remove unnecessary imports
-* Add messaging to messaging module
-* :pushpin: Automatic update of dependency thoth-common from 0.10.11 to 0.10.12
-* :pushpin: Automatic update of dependency pytest from 5.4.0 to 5.4.1
-* :pushpin: Automatic update of dependency pytest from 5.3.5 to 5.4.0
-* :pushpin: Automatic update of dependency thoth-common from 0.10.9 to 0.10.11
-* :pushpin: Automatic update of dependency thoth-common from 0.10.9 to 0.10.11
-* :pushpin: Automatic update of dependency thoth-common from 0.10.8 to 0.10.9
-* :pushpin: Automatic update of dependency faust from 1.10.3 to 1.10.4
-* :pushpin: Automatic update of dependency thoth-common from 0.10.7 to 0.10.8
-* :pushpin: Automatic update of dependency faust from 1.10.2 to 1.10.3
-* :pushpin: Automatic update of dependency thoth-common from 0.10.6 to 0.10.7
-* Release of version 0.3.2
-* updated github templates
-* relocked
-* Release of version 0.3.1
-* relocked
-* relocked
-* :pushpin: Automatic update of dependency thoth-common from 0.10.5 to 0.10.6
-* :pushpin: Automatic update of dependency faust from 1.10.1 to 1.10.2
-* Update .thoth.yaml
-* :pushpin: Automatic update of dependency thoth-common from 0.10.4 to 0.10.5
-* :pushpin: Automatic update of dependency thoth-common from 0.10.3 to 0.10.4
-* :pushpin: Automatic update of dependency thoth-common from 0.10.2 to 0.10.3
-* Release of version 0.3.0
-* :pushpin: Automatic update of dependency thoth-common from 0.10.1 to 0.10.2
-* :pushpin: Automatic update of dependency thoth-common from 0.10.0 to 0.10.1
-* :pushpin: Automatic update of dependency pytest from 5.3.4 to 5.3.5
-* :pushpin: Automatic update of dependency thoth-common from 0.9.31 to 0.10.0
-* :pushpin: Automatic update of dependency thoth-common from 0.9.30 to 0.9.31
-* :pushpin: Automatic update of dependency thoth-common from 0.9.29 to 0.9.30
-* :pushpin: Automatic update of dependency faust from 1.10.0 to 1.10.1
-* :pushpin: Automatic update of dependency pytest from 5.3.3 to 5.3.4
-* :pushpin: Automatic update of dependency thoth-common from 0.9.28 to 0.9.29
-* :pushpin: Automatic update of dependency pytest from 5.3.2 to 5.3.3
-* :pushpin: Automatic update of dependency thoth-common from 0.9.27 to 0.9.28
-* :pushpin: Automatic update of dependency thoth-common from 0.9.26 to 0.9.27
-* :pushpin: Automatic update of dependency thoth-common from 0.9.25 to 0.9.26
-* :pushpin: Automatic update of dependency faust from 1.9.0 to 1.10.0
-* :pushpin: Automatic update of dependency thoth-common from 0.9.24 to 0.9.25
-* :pushpin: Automatic update of dependency thoth-common from 0.9.23 to 0.9.24
-* :pushpin: Automatic update of dependency thoth-common from 0.9.22 to 0.9.23
-* :pushpin: Automatic update of dependency pytest-timeout from 1.3.3 to 1.3.4
-* Happy new year!
-* :pushpin: Automatic update of dependency pytest from 5.3.1 to 5.3.2
-* :pushpin: Automatic update of dependency thoth-common from 0.9.21 to 0.9.22
-* :pushpin: Automatic update of dependency thoth-common from 0.9.20 to 0.9.21
-* :pushpin: Automatic update of dependency thoth-common from 0.9.19 to 0.9.20
-* :pushpin: Automatic update of dependency thoth-common from 0.9.18 to 0.9.19
-* :pushpin: Automatic update of dependency thoth-common from 0.9.17 to 0.9.18
-* :pushpin: Automatic update of dependency thoth-common from 0.9.16 to 0.9.17
-* :pushpin: Automatic update of dependency pytest from 5.3.0 to 5.3.1
-* :pushpin: Automatic update of dependency pytest from 5.2.4 to 5.3.0
-* :pushpin: Automatic update of dependency pytest from 5.2.3 to 5.2.4
-* :pushpin: Automatic update of dependency pytest from 5.2.2 to 5.2.3
-* :pushpin: Automatic update of dependency thoth-common from 0.9.15 to 0.9.16
-* :pushpin: Automatic update of dependency thoth-common from 0.9.14 to 0.9.15
-* :pushpin: Automatic update of dependency faust from 1.8.1 to 1.9.0
-* :pushpin: Automatic update of dependency black from 19.3b0 to 19.10b0
-* :pushpin: Automatic update of dependency pytest from 5.2.1 to 5.2.2
-* :pushpin: Automatic update of dependency faust from 1.8.0 to 1.8.1
-* :pushpin: Automatic update of dependency thoth-common from 0.9.12 to 0.9.14
-* Release of version 0.2.1
-* :pushpin: Automatic update of dependency pytest-cov from 2.7.1 to 2.8.1
-* :pushpin: Automatic update of dependency pytest from 5.1.3 to 5.2.1
-* :pushpin: Automatic update of dependency faust from 1.7.4 to 1.8.0
-* :pushpin: Automatic update of dependency thoth-common from 0.9.10 to 0.9.12
-* Update .zuul.yaml
-* :green_heart: removed the pytest jobs from all pipelines
-* :green_heart: started adding tests
-* :green_heart: added the tests/ directory
-* :green_heart: remove the writing of test coverage data (for now)
-* oh, left over stuff we dont need was removed
-* added a release pipeline job to push to pypi
-* :sparkles: added create_topic, publish_to_topic
-* added the required requirements files
-* note required
-* added an explicite serializer
-* this is the basic set of files, updated ...
+- :pushpin: Automatic update of dependency pytest-timeout from 1.4.1 to 1.4.2 (#164)
+- Modify class not be initialized during import (#160)
+- Adjust message specs (#162)


### PR DESCRIPTION
revert the release of v0.5.0 and v0.6.0
Fixes: #165 

The cyborg sefkhet-abwy, missed updating a tag for v0.4.0, due to https://github.com/AICoE/Sefkhet-Abwy/issues/43.
which led to the creating of 0.5.0 and 0.6.0 version release. As these don't have any significant changes, just pointed to 0.4.0
revert them from the changelog.
:peace_symbol: will try to keep in check in the future.

Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>