### PR TITLE
include aicoe-ci configuration file

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,0 +1,15 @@
+check:
+  - thoth-precommit
+  - thoth-build
+build:
+  base-image: quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.0
+  build-stratergy: Source
+  registry: quay.io
+  registry-org: thoth-station
+  registry-project: messaging
+  registry-secret: thoth-station-thoth-pusher-secret
+deploy:
+  project-org: thoth-station
+  project-name: thoth-application
+  image-name: messaging
+  overlay-contextpath: core/overlays/test/imagestreamtags.yaml


### PR DESCRIPTION
include aicoe-ci configuration file
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

build and deploy image with aicoe-ci

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] No

## This Pull Request implements

aicoe-ci configuration file.

## Description

aicoe-ci would use this config file to build and push images.