### PR TITLE
allow ci to release the project to pypi

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,6 +1,8 @@
 check:
   - thoth-precommit
   - thoth-build
+release:
+  - upload-pypi-sesheta
 build:
   base-image: quay.io/thoth-station/s2i-thoth-ubi8-py36:v0.14.0
   build-stratergy: Source


### PR DESCRIPTION
allow ci to release the project to pypi
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

aicoe-ci failed to release the application new version 0.6.3 to pypi.

## This introduces a breaking change

- [x] No

## This should yield a new module release

- [x] No

## This Pull Request implements

updated the ci config file, for it to release the application to pypi.

## Description

aicoe-ci looks for the release params in the config file.