### PR TITLE
prepend deployment_name if it exists

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -106,6 +106,7 @@ async def messaging(
 
     tasks = []
 
+    # NOTE: we don't need to check based on deployment because it is only prepended after we call __init__
     async for m in all_messages:
         m_contents = m["message_contents"]
         m_topic_name = m["topic_name"]

--- a/thoth/messaging/message_base.py
+++ b/thoth/messaging/message_base.py
@@ -50,7 +50,10 @@ class MessageBase:
         protocol: str = "SSL",
     ):
         """Create general message."""
+        topic_prefix = os.getenv("THOTH_DEPLOYMENT_NAME", None)
         self.topic_name = topic_name or "thoth.base-topic"
+        if topic_prefix is not None:
+            self.topic_name = f"{topic_prefix}.{self.topic_name}"
         self.value_type = value_type
         self.num_partitions = num_partitions
         self.replication_factor = replication_factor


### PR DESCRIPTION
## Related Issues and Dependencies
https://github.com/thoth-station/messaging/issues/215

We use the same Kafka deployment for both stage and test so we prepend the deployment name in order to differentiate which deployment the messages are meant for.
