### PR TITLE
add default message contents for traceability

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -148,7 +148,3 @@ async def messaging(
         message = topic.MessageContents(**message_dict)
         await topic.topic.maybe_declare()
         await topic.publish_to_topic(message)
-
-    # loop = asyncio.get_event_loop()
-    # loop.run_until_complete(asyncio.gather(*tasks))
-    # loop.close()

--- a/cli.py
+++ b/cli.py
@@ -17,7 +17,6 @@
 
 """Messaging CLI to send single message to Kafka using Faust."""
 
-import asyncio
 import json
 from typing import Optional
 import logging
@@ -39,13 +38,19 @@ _LOGGER = logging.getLogger("thoth.messaging")
 ## create cli
 @app.command(
     cli.option(
-        "--topic-name", "-n", envvar="THOTH_MESSAGING_TOPIC_NAME", type=str, help="Name of topic to send message to.",
+        "--topic-name",
+        "-n",
+        envvar="THOTH_MESSAGING_TOPIC_NAME",
+        type=str,
+        help="Name of topic to send message to.",
+        required=False,
     ),
     cli.option(
         "--create-if-not-exist",
         envvar="THOTH_MESSAGING_CREATE_IF_NOT_EXIST",
         default=False,
         help="If topic doesn't already exist on Kafka then create it.",
+        flag_value=True,
     ),
     cli.option(
         "--message-contents",
@@ -53,6 +58,7 @@ _LOGGER = logging.getLogger("thoth.messaging")
         envvar="THOTH_MESSAGING_MESSAGE_CONTENTS",
         type=str,
         help="JSON representation of message to send including typing hints.",
+        required=False,
     ),  # {<name>: {"type":, "value":},...}
     cli.option(
         "--partitions",
@@ -79,6 +85,7 @@ _LOGGER = logging.getLogger("thoth.messaging")
         "--message-file",  # if present topic_name and message_contents will be ignored
         envvar="THOTH_MESSAGING_FROM_FILE",
         type=str,  # file path to file in json format [{"topic_name": <str>, "message_contents": <dict>}, ...]
+        required=False,
     ),
 )
 async def messaging(
@@ -105,15 +112,13 @@ async def messaging(
         temp_message["topic_name"] = topic_name
         all_messages = [temp_message]
 
-    tasks = []
-
     # NOTE: we don't need to check based on deployment because it is only prepended after we call __init__
-    async for m in all_messages:
+    for m in all_messages:
         m_contents = m["message_contents"]
         if "component_name" not in m_contents:
-            m_contents["component_name"] = "messaging-cli"
+            m_contents["component_name"] = {"value": "messaging-cli", "type": "str"}
         if "service_version" not in m_contents:
-            m_contents["service_version"] = messaging_version
+            m_contents["service_version"] = {"value": messaging_version, "type": "str"}
         m_topic_name = m["topic_name"]
         # get or create message type
         for message in ALL_MESSAGES:
@@ -134,12 +139,11 @@ async def messaging(
                 num_partitions=partitions,
                 topic_retention_time_second=topic_retention_time,
             )()
-
         message_dict = {i: m_contents[i]["value"] for i in m_contents}
         message = topic.MessageContents(**message_dict)
         await topic.topic.maybe_declare()
-        tasks.append(topic.publish_to_topic(message))
+        await topic.publish_to_topic(message)
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(asyncio.gather(*tasks))
-    loop.close()
+    # loop = asyncio.get_event_loop()
+    # loop.run_until_complete(asyncio.gather(*tasks))
+    # loop.close()

--- a/cli.py
+++ b/cli.py
@@ -28,6 +28,7 @@ from thoth.messaging import ALL_MESSAGES
 from thoth.messaging import message_factory
 from thoth.messaging import MessageBase
 from thoth.common import init_logging
+from thoth.messaging import __version__ as messaging_version
 
 app = MessageBase().app
 init_logging()
@@ -109,6 +110,10 @@ async def messaging(
     # NOTE: we don't need to check based on deployment because it is only prepended after we call __init__
     async for m in all_messages:
         m_contents = m["message_contents"]
+        if "component_name" not in m_contents:
+            m_contents["component_name"] = "messaging-cli"
+        if "service_version" not in m_contents:
+            m_contents["service_version"] = messaging_version
         m_topic_name = m["topic_name"]
         # get or create message type
         for message in ALL_MESSAGES:

--- a/thoth/messaging/__init__.py
+++ b/thoth/messaging/__init__.py
@@ -18,6 +18,7 @@
 """This is Thoth Messaging module."""
 
 from .message_base import MessageBase
+from .message_base import BaseMessageContents
 from .hash_mismatch import HashMismatchMessage
 from .missing_package import MissingPackageMessage
 from .missing_version import MissingVersionMessage
@@ -39,7 +40,7 @@ ALL_MESSAGES = [
     UnrevsolvedPackageMessage,
 ]
 
-__all__ = [msg_cls.__name__ for msg_cls in ALL_MESSAGES] + ["MessageBase", "message_factory"]
+__all__ = [msg_cls.__name__ for msg_cls in ALL_MESSAGES] + ["MessageBase", "message_factory", "BaseMessageContents"]
 
 
 __name__ = "thoth-messaging"

--- a/thoth/messaging/advise_justification.py
+++ b/thoth/messaging/advise_justification.py
@@ -20,9 +20,7 @@
 
 import logging
 
-import faust
-
-from .message_base import MessageBase
+from .message_base import MessageBase, BaseMessageContents
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +30,7 @@ class AdviseJustificationMessage(MessageBase):
 
     topic_name = "thoth.advise-reporter.advise-justification"
 
-    class MessageContents(faust.Record, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
 
         message: str

--- a/thoth/messaging/adviser_re_run.py
+++ b/thoth/messaging/adviser_re_run.py
@@ -20,11 +20,9 @@
 
 import logging
 
-import faust
-
 from typing import Optional, Dict, Any
 
-from .message_base import MessageBase
+from .message_base import MessageBase, BaseMessageContents
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +32,7 @@ class AdviserReRunMessage(MessageBase):
 
     topic_name = "thoth.investigator.adviser-re-run"
 
-    class MessageContents(faust.Record, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
 
         re_run_adviser_id: str

--- a/thoth/messaging/hash_mismatch.py
+++ b/thoth/messaging/hash_mismatch.py
@@ -18,8 +18,7 @@
 
 """This is Thoth Messaging module for HashMismatchMessage."""
 
-import faust
-from .message_base import MessageBase
+from .message_base import MessageBase, BaseMessageContents
 from typing import List
 
 
@@ -28,7 +27,7 @@ class HashMismatchMessage(MessageBase):
 
     topic_name = "thoth.package-update.hash-mismatch"
 
-    class MessageContents(faust.Record, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent a contents of a missing-package message Kafka topic."""
 
         index_url: str

--- a/thoth/messaging/message_base.py
+++ b/thoth/messaging/message_base.py
@@ -34,8 +34,8 @@ _LOGGER = logging.getLogger(__name__)
 class BaseMessageContents(faust.Record, serializer="json"):  # type: ignore
     """Default params for message contents."""
 
-    component_name: str = "WARNING: component_name not set"  # what component sent the message?
-    service_version: str = "WARNING: service_version not set"  # what version was that component?
+    component_name: str  # what component sent the message?
+    service_version: str  # what version was that component?
 
 
 class MessageBase:
@@ -76,6 +76,7 @@ class MessageBase:
         self.topic = MessageBase.app.topic(  # type: ignore
             self.topic_name,
             value_type=self.value_type,
+            key_type=self.value_type,
             retention=self.topic_retention_time_second,
             partitions=self.num_partitions,
             internal=True,
@@ -97,7 +98,6 @@ class MessageBase:
     async def publish_to_topic(self, value):
         """Publish to this messages topic."""
         await self.topic.send(value=value)
-        print("message sent")
 
     def sync_publish_to_topic(self, value):
         """Publish to topic synchronously."""

--- a/thoth/messaging/message_base.py
+++ b/thoth/messaging/message_base.py
@@ -31,6 +31,13 @@ from typing import Optional
 _LOGGER = logging.getLogger(__name__)
 
 
+class BaseMessageContents(faust.Record, serializer="json"):  # type: ignore
+    """Default params for message contents."""
+
+    component_name: str = "WARNING: component_name not set"  # what component sent the message?
+    service_version: str = "WARNING: service_version not set"  # what version was that component?
+
+
 class MessageBase:
     """Class used for Package Release events on Kafka topic."""
 

--- a/thoth/messaging/message_factory.py
+++ b/thoth/messaging/message_factory.py
@@ -18,15 +18,13 @@
 
 """This is Thoth Messaging module for message_factory."""
 
-import faust
-
 from typing import Tuple
 from typing import Dict  # noqa
 from typing import List  # noqa
 from typing import Set  # noqa
 from keyword import iskeyword
 
-from .message_base import MessageBase
+from .message_base import MessageBase, BaseMessageContents
 
 TYPE_SET = {
     "str",
@@ -64,7 +62,7 @@ def message_factory(
 
         topic_name = t_name
 
-        class MessageContents(faust.Record, serializer="json"):  # type: ignore
+        class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
             """Class used to represent a contents of a faust message Kafka topic."""
 
             for item in message_contents:

--- a/thoth/messaging/missing_package.py
+++ b/thoth/messaging/missing_package.py
@@ -18,8 +18,7 @@
 
 """This is Thoth Messaging module for MissingPackageMessage."""
 
-from .message_base import MessageBase
-import faust
+from .message_base import MessageBase, BaseMessageContents
 
 
 class MissingPackageMessage(MessageBase):
@@ -27,7 +26,7 @@ class MissingPackageMessage(MessageBase):
 
     topic_name = "thoth.package-update.missing-package"
 
-    class MessageContents(faust.Record, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent a contents of a missing-package message Kafka topic."""
 
         index_url: str

--- a/thoth/messaging/missing_version.py
+++ b/thoth/messaging/missing_version.py
@@ -19,8 +19,7 @@
 """This is Thoth Messaging module for MissingVersionMessage."""
 
 
-from .message_base import MessageBase
-import faust
+from .message_base import MessageBase, BaseMessageContents
 
 
 class MissingVersionMessage(MessageBase):
@@ -28,7 +27,7 @@ class MissingVersionMessage(MessageBase):
 
     topic_name = "thoth.package-update.missing-package-version"
 
-    class MessageContents(faust.Record, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent a contents of a missing-package message Kafka topic."""
 
         index_url: str

--- a/thoth/messaging/package_releases.py
+++ b/thoth/messaging/package_releases.py
@@ -18,8 +18,7 @@
 
 """This is Thoth Messaging module for PackageReleaseMessage."""
 
-from .message_base import MessageBase
-import faust
+from .message_base import MessageBase, BaseMessageContents
 
 
 class PackageReleaseMessage(MessageBase):
@@ -27,7 +26,7 @@ class PackageReleaseMessage(MessageBase):
 
     topic_name = "thoth.package-release.package-release"
 
-    class MessageContents(faust.Record, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent a contents of a missing-package message Kafka topic."""
 
         index_url: str

--- a/thoth/messaging/solved_package.py
+++ b/thoth/messaging/solved_package.py
@@ -20,9 +20,7 @@
 
 import logging
 
-import faust
-
-from .message_base import MessageBase
+from .message_base import MessageBase, BaseMessageContents
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,7 +30,7 @@ class SolvedPackageMessage(MessageBase):
 
     topic_name = "thoth.solver.solved-package"
 
-    class MessageContents(faust.Record, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
 
         package_name: str

--- a/thoth/messaging/unresolved_package.py
+++ b/thoth/messaging/unresolved_package.py
@@ -21,9 +21,7 @@
 import logging
 from typing import Optional, List
 
-import faust
-
-from .message_base import MessageBase
+from .message_base import MessageBase, BaseMessageContents
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,7 +31,7 @@ class UnresolvedPackageMessage(MessageBase):
 
     topic_name = "thoth.investigator.unresolved-package"
 
-    class MessageContents(faust.Record, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
 
         package_name: str

--- a/thoth/messaging/unrevsolved_package.py
+++ b/thoth/messaging/unrevsolved_package.py
@@ -19,9 +19,7 @@
 
 import logging
 
-import faust
-
-from .message_base import MessageBase
+from .message_base import MessageBase, BaseMessageContents
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +29,7 @@ class UnrevsolvedPackageMessage(MessageBase):
 
     topic_name = "thoth.investigator.unrevsolved-package"
 
-    class MessageContents(faust.Record, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
 
         package_name: str


### PR DESCRIPTION
## Related Issues and Dependencies
#216 

For traceability we want to be able to tell which component sent a message. I added a new class which represents contents which messages should all have by default.  We don't fail if these values aren't present but instead put warnings in the message as to not break the current implementation of our message senders.  If we have other values that we want in the messages by default, we can add them to this `BaseMessageContents` class.

I think as we add new features and contents to our messages we should add either a prefix or suffix representing the version of `thoth.messaging` to the topic name.  Please lmk if that is something you would like included in this PR or something that requires further discussion.
