### PR TITLE
Provide service version

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -38,7 +38,7 @@ _LOGGER = logging.getLogger("thoth.messaging")
 
 __service_version__ = f"{__version__}+common.{__common__version__}"
 
-_LOGGER.info("This is Thoth Messaginig CLI v%s", __service_version__)
+_LOGGER.info("This is Thoth Messaging CLI v%s", __service_version__)
 
 
 ## create cli

--- a/cli.py
+++ b/cli.py
@@ -28,11 +28,17 @@ from thoth.messaging import ALL_MESSAGES
 from thoth.messaging import message_factory
 from thoth.messaging import MessageBase
 from thoth.common import init_logging
+from thoth.messaging import __version__
+from thoth.common import __version__ as __common__version__
 
 app = MessageBase().app
 init_logging()
 
 _LOGGER = logging.getLogger("thoth.messaging")
+
+__service_version__ = f"{__version__}+common.{__common__version__}"
+
+_LOGGER.info("This is Thoth Messaginig CLI v%s", __service_version__)
 
 
 ## create cli


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

## Related Issues and Dependencies

Missing service version when using CLI in workflow task.

## This introduces a breaking change

- [ ] Yes
- [x] No

## This should yield a new module release

- [x] Yes
- [ ] No

## This Pull Request implements

Add service version to thoth-messaging CLI