### PR TITLE
add versions to all messages

### DIFF
--- a/thoth/messaging/advise_justification.py
+++ b/thoth/messaging/advise_justification.py
@@ -29,6 +29,7 @@ class AdviseJustificationMessage(MessageBase):
     """Class used for Advise justification events on Kafka topic."""
 
     topic_name = "thoth.advise-reporter.advise-justification"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of advise justification message Kafka topic."""
@@ -58,4 +59,5 @@ class AdviseJustificationMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/adviser_re_run.py
+++ b/thoth/messaging/adviser_re_run.py
@@ -31,6 +31,7 @@ class AdviserReRunMessage(MessageBase):
     """Class used for Adviser re run events on Kafka topic."""
 
     topic_name = "thoth.investigator.adviser-re-run"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of adviser re run message Kafka topic."""
@@ -70,4 +71,5 @@ class AdviserReRunMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/adviser_trigger.py
+++ b/thoth/messaging/adviser_trigger.py
@@ -32,6 +32,7 @@ class AdviserTriggerMessage(MessageBase):
     """Class used for Advise events on Kafka topic."""
 
     topic_name = "thoth.adviser-trigger"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
@@ -75,4 +76,5 @@ class AdviserTriggerMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/hash_mismatch.py
+++ b/thoth/messaging/hash_mismatch.py
@@ -26,6 +26,7 @@ class HashMismatchMessage(MessageBase):
     """Class used for Package Release events on Kafka topic."""
 
     topic_name = "thoth.package-update.hash-mismatch"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent a contents of a hash-mismatch message Kafka topic."""
@@ -57,4 +58,5 @@ class HashMismatchMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/kebechet_trigger.py
+++ b/thoth/messaging/kebechet_trigger.py
@@ -32,6 +32,7 @@ class KebechetTriggerMessage(MessageBase):
     """Class used for Kebechet events on Kafka topic."""
 
     topic_name = "thoth.kebechet-trigger"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
@@ -60,4 +61,5 @@ class KebechetTriggerMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/message_base.py
+++ b/thoth/messaging/message_base.py
@@ -42,6 +42,7 @@ class MessageBase:
     """Class used for Package Release events on Kafka topic."""
 
     app = None  # type: Optional[faust.App]
+    _base_version = 1  # update on schema change
 
     def __init__(
         self,
@@ -55,12 +56,14 @@ class MessageBase:
         bootstrap_server: str = "localhost:9092",
         topic_retention_time_second: int = 60 * 60 * 24 * 45,
         protocol: str = "SSL",
+        message_version: int = 0,
     ):
         """Create general message."""
         topic_prefix = os.getenv("THOTH_DEPLOYMENT_NAME", None)
         self.topic_name = topic_name or "thoth.base-topic"
         if topic_prefix is not None:
             self.topic_name = f"{topic_prefix}.{self.topic_name}"
+        self.topic_name = f"{self.topic_name}.v{self._base_version}.{message_version}"
         self.value_type = value_type
         self.num_partitions = num_partitions
         self.replication_factor = replication_factor

--- a/thoth/messaging/message_factory.py
+++ b/thoth/messaging/message_factory.py
@@ -61,6 +61,7 @@ def message_factory(
         """Class used for any events on Kafka topic."""
 
         topic_name = t_name
+        # we cannot have a message version for message factory so it will just default to v{message_base}.0
 
         class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
             """Class used to represent a contents of a faust message Kafka topic."""

--- a/thoth/messaging/missing_package.py
+++ b/thoth/messaging/missing_package.py
@@ -25,6 +25,7 @@ class MissingPackageMessage(MessageBase):
     """Class used for Package Release events on Kafka topic."""
 
     topic_name = "thoth.package-update.missing-package"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent a contents of a missing-package message Kafka topic."""
@@ -53,4 +54,5 @@ class MissingPackageMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/missing_version.py
+++ b/thoth/messaging/missing_version.py
@@ -26,6 +26,7 @@ class MissingVersionMessage(MessageBase):
     """Class used for Package Release events on Kafka topic."""
 
     topic_name = "thoth.package-update.missing-package-version"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent a contents of a missing-package version message Kafka topic."""
@@ -55,4 +56,5 @@ class MissingVersionMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/package_extract_trigger.py
+++ b/thoth/messaging/package_extract_trigger.py
@@ -30,6 +30,7 @@ class PackageExtractTriggerMessage(MessageBase):
     """Class used for Package Extract events on Kafka topic."""
 
     topic_name = "thoth.package-extract-trigger"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
@@ -65,4 +66,5 @@ class PackageExtractTriggerMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/package_releases.py
+++ b/thoth/messaging/package_releases.py
@@ -25,6 +25,7 @@ class PackageReleasedMessage(MessageBase):
     """Class used for Package Release events on Kafka topic."""
 
     topic_name = "thoth.package-release.package-released"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a package-released message Kafka topic."""
@@ -53,4 +54,5 @@ class PackageReleasedMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/provenance_checker_trigger.py
+++ b/thoth/messaging/provenance_checker_trigger.py
@@ -33,6 +33,7 @@ class ProvenanceCheckerTriggerMessage(MessageBase):
     """Class used for Provenance Checker events on Kafka topic."""
 
     topic_name = "thoth.provenance-checker-trigger"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
@@ -64,4 +65,5 @@ class ProvenanceCheckerTriggerMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/qebhwt_trigger.py
+++ b/thoth/messaging/qebhwt_trigger.py
@@ -30,6 +30,7 @@ class QebHwtTriggerMessage(MessageBase):
     """Class used for QebHwt events on Kafka topic."""
 
     topic_name = "thoth.qebhwt-trigger"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
@@ -65,4 +66,5 @@ class QebHwtTriggerMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/si_unanalyzed_package.py
+++ b/thoth/messaging/si_unanalyzed_package.py
@@ -28,6 +28,7 @@ class SIUnanalyzedPackageMessage(MessageBase):
     """Class used by Producer events on Kafka topic on packages not analyzed by SI."""
 
     topic_name = "thoth.investigator.si-unanalyzed-package"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a SI unanalyzed package message Kafka topic."""
@@ -57,4 +58,5 @@ class SIUnanalyzedPackageMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/solved_package.py
+++ b/thoth/messaging/solved_package.py
@@ -29,6 +29,7 @@ class SolvedPackageMessage(MessageBase):
     """Class used for Solved Package events on Kafka topic."""
 
     topic_name = "thoth.solver.solved-package"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a solved package message Kafka topic."""
@@ -59,4 +60,5 @@ class SolvedPackageMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/unresolved_package.py
+++ b/thoth/messaging/unresolved_package.py
@@ -30,6 +30,7 @@ class UnresolvedPackageMessage(MessageBase):
     """Class used by Investigator producer events on Kafka topic."""
 
     topic_name = "thoth.investigator.unresolved-package"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a unresolved package message Kafka topic."""
@@ -60,4 +61,5 @@ class UnresolvedPackageMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )

--- a/thoth/messaging/unrevsolved_package.py
+++ b/thoth/messaging/unrevsolved_package.py
@@ -28,6 +28,7 @@ class UnrevsolvedPackageMessage(MessageBase):
     """Class used by Producer events on Kafka topic on Reverse Solver events."""
 
     topic_name = "thoth.investigator.unrevsolved-package"
+    _message_version = 1  # update on schema change
 
     class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
         """Class used to represent contents of a unrevsolved package message Kafka topic."""
@@ -56,4 +57,5 @@ class UnrevsolvedPackageMessage(MessageBase):
             bootstrap_server=bootstrap_server,
             topic_retention_time_second=topic_retention_time_second,
             protocol=protocol,
+            message_version=self._message_version,
         )


### PR DESCRIPTION
## This introduces a breaking change

- [x] Yes
- [ ] No

When this module is released any currently pending messages will not be consumed.

## This should yield a new module release

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Add versioning for messages so that investigator or other consumers will only consume messages for which their message schema matches the message's

## Description

Give each message type a version as well as base message.  These will be appended concatenated and added to the topic name so that it becomes something like: `{deployment}.{topic_name}.v{base_message}.{message_version}`
