### PR TITLE
Confluent rework

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,8 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-faust = "*"
 thoth-common = "*"
+confluent-kafka = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6cc92298545eaa0c7b782d916c00c9bce62a9dfeb74917fb5b32ee9ffdf21846"
+            "sha256": "31a431a0f5f7978ff00ea0d351d00905cdf03b76044ec9c03cdd93ffbcd4dcd1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,51 +16,12 @@
         ]
     },
     "default": {
-        "aiocontextvars": {
-            "hashes": [
-                "sha256:885daf8261818767d8f7cbd79f9d4482d118f024b6586ef6e67980236a27bfa3",
-                "sha256:f027372dc48641f683c559f247bd84962becaacdc9ba711d583c3871fb5652aa"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==0.2.2"
-        },
-        "aiohttp": {
-            "hashes": [
-                "sha256:1e984191d1ec186881ffaed4581092ba04f7c61582a177b187d3a2f07ed9719e",
-                "sha256:259ab809ff0727d0e834ac5e8a283dc5e3e0ecc30c4d80b3cd17a4139ce1f326",
-                "sha256:2f4d1a4fdce595c947162333353d4a44952a724fba9ca3205a3df99a33d1307a",
-                "sha256:32e5f3b7e511aa850829fbe5aa32eb455e5534eaa4b1ce93231d00e2f76e5654",
-                "sha256:344c780466b73095a72c616fac5ea9c4665add7fc129f285fbdbca3cccf4612a",
-                "sha256:460bd4237d2dbecc3b5ed57e122992f60188afe46e7319116da5eb8a9dfedba4",
-                "sha256:4c6efd824d44ae697814a2a85604d8e992b875462c6655da161ff18fd4f29f17",
-                "sha256:50aaad128e6ac62e7bf7bd1f0c0a24bc968a0c0590a726d5a955af193544bcec",
-                "sha256:6206a135d072f88da3e71cc501c59d5abffa9d0bb43269a6dcd28d66bfafdbdd",
-                "sha256:65f31b622af739a802ca6fd1a3076fd0ae523f8485c52924a89561ba10c49b48",
-                "sha256:ae55bac364c405caa23a4f2d6cfecc6a0daada500274ffca4a9230e7129eac59",
-                "sha256:b778ce0c909a2653741cb4b1ac7015b5c130ab9c897611df43ae6a58523cb965"
-            ],
-            "version": "==3.6.2"
-        },
-        "aiohttp-cors": {
-            "hashes": [
-                "sha256:0451ba59fdf6909d0e2cd21e4c0a43752bc0703d33fc78ae94d9d9321710193e",
-                "sha256:4d39c6d7100fd9764ed1caf8cebf0eb01bf5e3f24e2e073fda6234bc48b19f5d"
-            ],
-            "version": "==0.7.0"
-        },
         "argo-workflows": {
             "hashes": [
                 "sha256:5198066fb57fff325332b8a897c018df8ec6a61aef972676f9c7b04ff8327fdf",
                 "sha256:d77b58a13f5a63515fe6ce2c9f2301cbb1c37fee9fe38d906ebd1e8fb557c935"
             ],
             "version": "==3.5.1"
-        },
-        "async-timeout": {
-            "hashes": [
-                "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
-                "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
-            ],
-            "version": "==3.0.1"
         },
         "attrdict": {
             "hashes": [
@@ -74,6 +35,7 @@
                 "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
                 "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.2.0"
         },
         "cachetools": {
@@ -81,6 +43,7 @@
                 "sha256:513d4ff98dd27f85743a8dc0e92f55ddb1b49e060c2d5961512855cda2c01a98",
                 "sha256:bbaa39c3dede00175df2dc2b03d0cf18dd2d32a7de7beb68072d13043c9edb20"
             ],
+            "markers": "python_version ~= '3.5'",
             "version": "==4.1.1"
         },
         "certifi": {
@@ -97,39 +60,37 @@
             ],
             "version": "==3.0.4"
         },
-        "click": {
+        "confluent-kafka": {
             "hashes": [
-                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
-                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+                "sha256:00acc73f7d49961bf427f5e4fd6c0a220a6bfa5ccc91e0ad1f9ffa1751a169b0",
+                "sha256:0a59afbb90bdd22b9acdd3bb134f5ee1dff3cc5df55eaf52bf97b2f8d0d00de3",
+                "sha256:13b0e2011560f461ff39daf38089dd7f91404b3e66dba0456ccce0700f93c4f2",
+                "sha256:175c7064c8f19975616974558c45f42c147a202d4b1c0b0a83afefb920367696",
+                "sha256:22d7201d1aa89f1c5546749e781492925ed3eb0d7bd8f781fc57294cd45ddde3",
+                "sha256:3034cacc3b0d03eb3ce39cc5a64c1070d223870246f5d90c9113996be9db7df8",
+                "sha256:3e2d4f55ca952aeada3831d6615dc13a8a42c8e97175855ca08bbc6e6091b080",
+                "sha256:5a1c47320d6afc5b2599f8f8e143aed6845a2d903facde984606e02f10f11221",
+                "sha256:7b03bd9cc7b5e4df0a27eed359762c61a35313d4981ef1d9b418069eee454e66",
+                "sha256:85ff4823770ce2efaabb46d88e5ae26a840e0051fd481abaa805f21a5a84d003",
+                "sha256:9534cd2c0313df75b70eb4cf729382998970d97bbdda5cf3aef7081b855ccebe",
+                "sha256:99b13d0957a5967c85aee6138ef5f9acec90294267a549c5683744f20cf5d7b4",
+                "sha256:9a1c77291c1ac4b991aa0358f2f44636686eb8f52fb628502d30c312160a14e9",
+                "sha256:9ac812006000887f76c95b8a33a9f0b65845bf072fbc54a42a1acffd34e41120",
+                "sha256:9c47b8aacfe347bffd86bf75b98626718912b63df87f256dff1abc06a0355410",
+                "sha256:a116382ae67e0d6a54684bab4ee9b1be54e789d031a6e5e74c3edc657c79d23c",
+                "sha256:b1c89f3653385acc5da71570e03281f35ac6960367f2b2a426ae431deb1a1a35",
+                "sha256:bb77276d569f511abe4a5b32a53f8a30285bc7be68219e5711a44720bf356ac2",
+                "sha256:bbd9633552840ab9367fb762ea21272759db8caec2c34ff16ee28be177644cdf",
+                "sha256:bfdfa81e4e72d2c24e408a5e199aae0a477499ae40647dfa6906d002d9b07f38",
+                "sha256:c7461d6db081c23a6d38ceba348e7c178d7e974cf22c45ba8a4918ecb8855a44",
+                "sha256:d6a5d4c72360a75e875e88f7cce42b66a786d037ca2002303ab1c580d49caf53",
+                "sha256:dabed41cc60d1fc6d3cb44a90fe02e5192c9bf0f73c7b35761981e62ecabc592",
+                "sha256:dd544847c713eeeb525031348ff6ffea4ecdd11c13590893e599a9d4676a9bd4",
+                "sha256:eba169a9de8c978c9f33c763857c5279eceac46a4fd55a381c2528b9d4b3359e",
+                "sha256:f2d1ee0bfdf618017bbfaa42406546155c1a86263e4f286295318578c723803b"
             ],
-            "version": "==7.1.2"
-        },
-        "colorclass": {
-            "hashes": [
-                "sha256:b05c2a348dfc1aff2d502527d78a5b7b7e2f85da94a96c5081210d8e9ee8e18b"
-            ],
-            "version": "==2.2.0"
-        },
-        "colorlog": {
-            "hashes": [
-                "sha256:43597fd822ce705190fc997519342fdaaf44b9b47f896ece7aa153ed4b909c74",
-                "sha256:75e55822c3a3387d721579241e776de2cf089c9ef9528b1f09e8b04d403ad118"
-            ],
-            "version": "==4.2.1"
-        },
-        "contextvars": {
-            "hashes": [
-                "sha256:f38c908aaa59c14335eeea12abea5f443646216c4e29380d7bf34d2018e2c39e"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==2.4"
-        },
-        "croniter": {
-            "hashes": [
-                "sha256:15597ef0639f8fbab09cbf8c277fa8c65c8b9dbe818c4b2212f95dbc09c6f287",
-                "sha256:7186b9b464f45cf3d3c83a18bc2344cc101d7b9fd35a05f2878437b14967e964"
-            ],
-            "version": "==0.3.34"
+            "index": "pypi",
+            "version": "==1.5.0"
         },
         "daiquiri": {
             "hashes": [
@@ -138,22 +99,12 @@
             ],
             "version": "==2.1.1"
         },
-        "faust": {
-            "hashes": [
-                "sha256:128dc0b9483aa4009edcc8b23f5c132757f2329c5da1fcc144d4c1d1dd63f156",
-                "sha256:4ae94762a16c3ef70aa1e77772ff94395c2068ecbb99e1acce252d0f1156bd2c",
-                "sha256:abaade164bde21cd5f41dff24a203ff91f2c935c849c8e6a807f854bf84ea77d",
-                "sha256:cfd47e756825eb8c6d197c1a2f25199aef2895cd31b522c74ec2dbb95dfa6fcc",
-                "sha256:ffcd350ea29d528f6814fc9a42b5e50e130310da054a93e9d8216ef89a254611"
-            ],
-            "index": "pypi",
-            "version": "==1.10.4"
-        },
         "google-auth": {
             "hashes": [
                 "sha256:712dd7d140a9a1ea218e5688c7fcb04af71b431a29ec9ce433e384c60e387b98",
                 "sha256:9c0f71789438d703f77b94aad4ea545afaec9a65f10e6cc1bc8b89ce242244bb"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.22.1"
         },
         "idna": {
@@ -161,51 +112,23 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
-        },
-        "idna-ssl": {
-            "hashes": [
-                "sha256:a933e3bb13da54383f9e8f35dc4f9cb9eb9b3b78c6b36f311254d6d0d92c6c7c"
-            ],
-            "markers": "python_version < '3.7'",
-            "version": "==1.1.0"
-        },
-        "immutables": {
-            "hashes": [
-                "sha256:1c11050c49e193a1ec9dda1747285333f6ba6a30bbeb2929000b9b1192097ec0",
-                "sha256:33ce2f977da7b5e0dddd93744862404bdb316ffe5853ec853e53141508fa2e6a",
-                "sha256:6c8eace4d98988c72bcb37c05e79aae756832738305ae9497670482a82db08bc",
-                "sha256:714aedbdeba4439d91cb5e5735cb10631fc47a7a69ea9cc8ecbac90322d50a4a",
-                "sha256:860666fab142401a5535bf65cbd607b46bc5ed25b9d1eb053ca8ed9a1a1a80d6",
-                "sha256:8797eed4042f4626b0bc04d9cf134208918eb0c937a8193a2c66df5041e62d2e",
-                "sha256:a0a1cc238b678455145bae291d8426f732f5255537ed6a5b7645949704c70a78",
-                "sha256:ab6c18b7b2b2abc83e0edc57b0a38bf0915b271582a1eb8c7bed1c20398f8040",
-                "sha256:c099212fd6504513a50e7369fe281007c820cf9d7bb22a336486c63d77d6f0b2",
-                "sha256:c453e12b95e1d6bb4909e8743f88b7f5c0c97b86a8bc0d73507091cb644e3c1e",
-                "sha256:ce01788878827c3f0331c254a4ad8d9721489a5e65cc43e19c80040b46e0d297",
-                "sha256:ef9da20ec0f1c5853b5c8f8e3d9e1e15b8d98c259de4b7515d789a606af8745e"
-            ],
-            "version": "==0.14"
         },
         "jinja2": {
             "hashes": [
                 "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
                 "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.11.2"
         },
         "jsonformatter": {
             "hashes": [
                 "sha256:c9d40c34eadc6fd72281f276645ba39efeccf1a21435971f11c424f956a5060d"
             ],
+            "markers": "python_version >= '2.7'",
             "version": "==0.3.0"
-        },
-        "kafka-python": {
-            "hashes": [
-                "sha256:2f29baad4b3efe05a2bb81ac268855aa01cbc68397f15bac77b494ffd7e2cada",
-                "sha256:4fbebebfcb6fc94903fb720fe883d7bbec7298f4f1acb857c21dd3b4b114ba4b"
-            ],
-            "version": "==1.4.7"
         },
         "kubernetes": {
             "hashes": [
@@ -250,6 +173,7 @@
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
                 "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
         "mock": {
@@ -257,56 +181,15 @@
                 "sha256:3f9b2c0196c60d21838f307f5825a7b86b678cedc58ab9e50a8988187b4d81e0",
                 "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==4.0.2"
-        },
-        "mode": {
-            "hashes": [
-                "sha256:2df1a558dcaa42a7f9a983acb33438371a668076171be19b4c94bf0cdfd6e2eb",
-                "sha256:e54deee3b1988b1553425ab8b99fad957d56367eccc0d912fe009998ab651a82"
-            ],
-            "version": "==4.3.2"
-        },
-        "multidict": {
-            "hashes": [
-                "sha256:1ece5a3369835c20ed57adadc663400b5525904e53bae59ec854a5d36b39b21a",
-                "sha256:275ca32383bc5d1894b6975bb4ca6a7ff16ab76fa622967625baeebcf8079000",
-                "sha256:3750f2205b800aac4bb03b5ae48025a64e474d2c6cc79547988ba1d4122a09e2",
-                "sha256:4538273208e7294b2659b1602490f4ed3ab1c8cf9dbdd817e0e9db8e64be2507",
-                "sha256:5141c13374e6b25fe6bf092052ab55c0c03d21bd66c94a0e3ae371d3e4d865a5",
-                "sha256:51a4d210404ac61d32dada00a50ea7ba412e6ea945bbe992e4d7a595276d2ec7",
-                "sha256:5cf311a0f5ef80fe73e4f4c0f0998ec08f954a6ec72b746f3c179e37de1d210d",
-                "sha256:6513728873f4326999429a8b00fc7ceddb2509b01d5fd3f3be7881a257b8d463",
-                "sha256:7388d2ef3c55a8ba80da62ecfafa06a1c097c18032a501ffd4cabbc52d7f2b19",
-                "sha256:9456e90649005ad40558f4cf51dbb842e32807df75146c6d940b6f5abb4a78f3",
-                "sha256:c026fe9a05130e44157b98fea3ab12969e5b60691a276150db9eda71710cd10b",
-                "sha256:d14842362ed4cf63751648e7672f7174c9818459d169231d03c56e84daf90b7c",
-                "sha256:e0d072ae0f2a179c375f67e3da300b47e1a83293c554450b29c900e50afaae87",
-                "sha256:f07acae137b71af3bb548bd8da720956a3bc9f9a0b87733e0899226a2317aeb7",
-                "sha256:fbb77a75e529021e7c4a8d4e823d88ef4d23674a202be4f5addffc72cbb91430",
-                "sha256:fcfbb44c59af3f8ea984de67ec7c306f618a3ec771c2843804069917a8f2e255",
-                "sha256:feed85993dbdb1dbc29102f50bca65bdc68f2c0c8d352468c25b54874f23c39d"
-            ],
-            "version": "==4.7.6"
-        },
-        "mypy-extensions": {
-            "hashes": [
-                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
-            ],
-            "version": "==0.4.3"
-        },
-        "natsort": {
-            "hashes": [
-                "sha256:a633464dc3a22b305df0f27abcb3e83515898aa1fd0ed2f9726c3571a27258cf",
-                "sha256:d3fd728a3ceb7c78a59aa8539692a75e37cbfd9b261d4d702e8016639820f90a"
-            ],
-            "version": "==7.0.1"
         },
         "oauthlib": {
             "hashes": [
                 "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889",
                 "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.1.0"
         },
         "openshift": {
@@ -315,23 +198,39 @@
             ],
             "version": "==0.11.2"
         },
-        "opentracing": {
-            "hashes": [
-                "sha256:9b3f7c7a20c34170b9253c97121256264daf6b5f090035c732c6e2548cc5c0a7"
-            ],
-            "version": "==1.3.0"
-        },
         "pyasn1": {
             "hashes": [
+                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
+                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
+                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
+                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
                 "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
-                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
+                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
+                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
+                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
+                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
+                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
+                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
+                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
             ],
             "version": "==0.4.8"
         },
         "pyasn1-modules": {
             "hashes": [
+                "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8",
+                "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199",
+                "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811",
+                "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed",
+                "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4",
                 "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e",
-                "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74"
+                "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74",
+                "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb",
+                "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45",
+                "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd",
+                "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0",
+                "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d",
+                "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"
             ],
             "version": "==0.2.8"
         },
@@ -340,12 +239,14 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "python-json-logger": {
             "hashes": [
                 "sha256:6c15023a8571200228472d4c9de7cb891cd45f670061f7729b8209bf643d5bbf"
             ],
+            "markers": "python_version >= '3.4'",
             "version": "==2.0.0"
         },
         "python-string-utils": {
@@ -353,6 +254,7 @@
                 "sha256:dcf9060b03f07647c0a603408dc8b03f807f3b54a05c6e19eb14460256fac0cb",
                 "sha256:f1a88700baf99db1a9b6953f44181ad9ca56623c81e257e6009707e2e7851fa4"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==1.0.0"
         },
         "pytz": {
@@ -383,12 +285,14 @@
                 "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
                 "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.24.0"
         },
         "requests-oauthlib": {
             "hashes": [
                 "sha256:7f71572defaecd16372f9006f33c2ec8c077c3cfa6f5911a9a90202beb513f3d",
-                "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a"
+                "sha256:b4261601a71fd721a8bd6d7aa1cc1d6a8a93b4a9f5e96626f8e4d91e8beeaa6a",
+                "sha256:fa6c47b933f01060936d87ae9327fead68768b69c6c9ea2109c48be30f2d4dbc"
             ],
             "version": "==1.3.0"
         },
@@ -398,16 +302,6 @@
                 "sha256:eaba528e47fba3e2845d52d559885cbc27a37db42a9d265ea539b3b4452d3057"
             ],
             "version": "==1.4.3"
-        },
-        "robinhood-aiokafka": {
-            "hashes": [
-                "sha256:12ab446ec50634b53f5a7d16502a5b048ae68f8075a568be54c0197cef549afd",
-                "sha256:a1c468d0780ad903fce41fc0ff98b37ddf390470554303c335a86b24768f677a",
-                "sha256:b5ac0591a3c5a61fcfb316acfe7b4bfa336f20f048642be769bd0a321b94acda",
-                "sha256:d8d03d73d3af3e9e74d01085294eb2848d06b4bd79ec90c0fd0be2142fabe530",
-                "sha256:efe6bdc0d6bb07945135799f34f436d2ec912774b096765daa189a66e2f89faa"
-            ],
-            "version": "==1.1.6"
         },
         "rsa": {
             "hashes": [
@@ -449,7 +343,7 @@
                 "sha256:e9f7d1d8c26a6a12c23421061f9022bb62704e38211fe375c645485f38df34a2",
                 "sha256:f6061a31880c1ed6b6ce341215336e2f3d0c1deccd84957b6fa8ca474b41e89f"
             ],
-            "markers": "platform_python_implementation == 'CPython' and python_version < '3.9'",
+            "markers": "python_version < '3.9' and platform_python_implementation == 'CPython'",
             "version": "==0.2.2"
         },
         "sentry-sdk": {
@@ -464,13 +358,8 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
-        },
-        "terminaltables": {
-            "hashes": [
-                "sha256:f3eb0eb92e3833972ac36796293ca0906e998dc3be91fbe1f8615b331b853b81"
-            ],
-            "version": "==3.1.0"
         },
         "thoth-common": {
             "hashes": [
@@ -479,15 +368,6 @@
             ],
             "index": "pypi",
             "version": "==0.20.0"
-        },
-        "typing-extensions": {
-            "hashes": [
-                "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918",
-                "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
-                "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==3.7.4.3"
         },
         "tzlocal": {
             "hashes": [
@@ -501,14 +381,8 @@
                 "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
                 "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.10"
-        },
-        "venusian": {
-            "hashes": [
-                "sha256:2f2d077a1eedc3fda40425f65687c8c494da7e83d7c23bc2c4d1a40eb3ca5b6d",
-                "sha256:64ec8285b80b110d0ae5db4280e90e31848a59db98db1aba4d7d46f48ce91e3e"
-            ],
-            "version": "==1.2.0"
         },
         "websocket-client": {
             "hashes": [
@@ -516,28 +390,6 @@
                 "sha256:d735b91d6d1692a6a181f2a8c9e0238e5f6373356f561bb9dc4c7af36f452010"
             ],
             "version": "==0.57.0"
-        },
-        "yarl": {
-            "hashes": [
-                "sha256:04a54f126a0732af75e5edc9addeaa2113e2ca7c6fce8974a63549a70a25e50e",
-                "sha256:3cc860d72ed989f3b1f3abbd6ecf38e412de722fb38b8f1b1a086315cf0d69c5",
-                "sha256:5d84cc36981eb5a8533be79d6c43454c8e6a39ee3118ceaadbd3c029ab2ee580",
-                "sha256:5e447e7f3780f44f890360ea973418025e8c0cdcd7d6a1b221d952600fd945dc",
-                "sha256:61d3ea3c175fe45f1498af868879c6ffeb989d4143ac542163c45538ba5ec21b",
-                "sha256:67c5ea0970da882eaf9efcf65b66792557c526f8e55f752194eff8ec722c75c2",
-                "sha256:6f6898429ec3c4cfbef12907047136fd7b9e81a6ee9f105b45505e633427330a",
-                "sha256:7ce35944e8e61927a8f4eb78f5bc5d1e6da6d40eadd77e3f79d4e9399e263921",
-                "sha256:b7c199d2cbaf892ba0f91ed36d12ff41ecd0dde46cbf64ff4bfe997a3ebc925e",
-                "sha256:c15d71a640fb1f8e98a1423f9c64d7f1f6a3a168f803042eaf3a5b5022fde0c1",
-                "sha256:c22607421f49c0cb6ff3ed593a49b6a99c6ffdeaaa6c944cdda83c2393c8864d",
-                "sha256:c604998ab8115db802cc55cb1b91619b2831a6128a62ca7eea577fc8ea4d3131",
-                "sha256:d088ea9319e49273f25b1c96a3763bf19a882cff774d1792ae6fba34bd40550a",
-                "sha256:db9eb8307219d7e09b33bcb43287222ef35cbcf1586ba9472b0a4b833666ada1",
-                "sha256:e31fef4e7b68184545c3d68baec7074532e077bd1906b040ecfba659737df188",
-                "sha256:e32f0fb443afcfe7f01f95172b66f279938fbc6bdaebe294b0ff6747fb6db020",
-                "sha256:fcbe419805c9b20db9a51d33b942feddbf6e7fb468cb20686fd7089d4164c12a"
-            ],
-            "version": "==1.6.0"
         }
     },
     "develop": {
@@ -546,6 +398,7 @@
                 "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703",
                 "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==2.4.2"
         },
         "attrs": {
@@ -553,6 +406,7 @@
                 "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594",
                 "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.2.0"
         },
         "coverage": {
@@ -592,6 +446,7 @@
                 "sha256:cedb2f9e1f990918ea061f28a0f0077a07702e3819602d3507e2ff98c8d20636",
                 "sha256:e8caf961e1b1a945db76f1b5fa9c91498d15f545ac0ababbe575cfab185d3bd8"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==5.3"
         },
         "importlib-metadata": {
@@ -614,6 +469,7 @@
                 "sha256:36f0c6659b9000597e92618d05b72d4181104cf59472b1c6a039e3783f930c95",
                 "sha256:ba040c24d20aa302f78f4747df549573ae1eaf8e1084269199154da9c483f07f"
             ],
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==5.5.4"
         },
         "lazy-object-proxy": {
@@ -640,6 +496,7 @@
                 "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
                 "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.4.3"
         },
         "mccabe": {
@@ -654,6 +511,7 @@
                 "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
                 "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.4"
         },
         "pluggy": {
@@ -661,6 +519,7 @@
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "py": {
@@ -668,6 +527,7 @@
                 "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
                 "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.9.0"
         },
         "pylint": {
@@ -683,6 +543,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -714,6 +575,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "toml": {
@@ -747,7 +609,7 @@
                 "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
                 "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
-            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
+            "markers": "python_version < '3.8' and implementation_name == 'cpython'",
             "version": "==1.4.1"
         },
         "wrapt": {
@@ -761,6 +623,7 @@
                 "sha256:64ad89efee774d1897a58607895d80789c59778ea02185dd846ac38394a8642b",
                 "sha256:eed8ec0b8d1416b2ca33516a37a08892442f3954dee131e92cfd92d8fe3e7066"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==3.3.0"
         }
     }

--- a/thoth/messaging/admin_client.py
+++ b/thoth/messaging/admin_client.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# thoth-messaging
+# Copyright(C) 2020 Kevin Postlethwait
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Helper functions for using confluent kafka admin client with thoth.messaging."""
+
+from typing import Optional, Dict
+
+from .config import kafka_config_from_env, topic_config_from_env
+from . import ALL_MESSAGES
+
+from confluent_kafka.admin import AdminClient, NewTopic
+
+
+def create_admin_client(config: Optional[Dict[str, str]] = None) -> AdminClient:
+    """Create admin client."""
+    if config:
+        return AdminClient(config)
+    return AdminClient(kafka_config_from_env())
+
+
+def create_all_topics(admin: AdminClient, partitions: int = 1, replication_factor: int = 1):
+    """Create admin client for all topics in thoth messaging with equal replication and partitions."""
+    # NOTE: topics are only created if they don't exist
+    topics = admin.list_topics().topics
+    for i in ALL_MESSAGES:
+        t_name = i().topic_name
+        if t_name in topics:
+            continue
+        admin.create_topics(
+            [NewTopic(t_name, partitions, replication_factor=replication_factor, config=topic_config_from_env(),)]
+        )

--- a/thoth/messaging/advise_justification.py
+++ b/thoth/messaging/advise_justification.py
@@ -19,6 +19,7 @@
 """This is Thoth Messaging module for AdviseJustificationMessage."""
 
 import logging
+import attr
 
 from .message_base import MessageBase, BaseMessageContents
 
@@ -28,37 +29,20 @@ _LOGGER = logging.getLogger(__name__)
 class AdviseJustificationMessage(MessageBase):
     """Class used for Advise justification events on Kafka topic."""
 
-    topic_name = "thoth.advise-reporter.advise-justification"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.advise-reporter.advise-justification"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of advise justification message Kafka topic."""
 
-        message: str
-        justification_type: str
-        count: int
-        adviser_version: str
+        message = attr.ib(type=str)
+        justification_type = attr.ib(type=str)
+        count = attr.ib(type=int)
+        adviser_version = attr.ib(type=str)
+        version = attr.ib(type=str, default="v1", init=False)
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self,):
         """Initialize advise-justification topic."""
         super(AdviseJustificationMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/adviser_re_run.py
+++ b/thoth/messaging/adviser_re_run.py
@@ -19,6 +19,7 @@
 """This is Thoth Messaging module for AdviserReRunMessage."""
 
 import logging
+import attr
 
 from typing import Optional, Dict, Any
 
@@ -30,17 +31,17 @@ _LOGGER = logging.getLogger(__name__)
 class AdviserReRunMessage(MessageBase):
     """Class used for Adviser re run events on Kafka topic."""
 
-    topic_name = "thoth.investigator.adviser-re-run"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.investigator.adviser-re-run"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of adviser re run message Kafka topic."""
 
-        re_run_adviser_id: str
+        re_run_adviser_id = attr.ib(type=str)
 
-        application_stack: Dict[Any, Any]
-        recommendation_type: str
-        runtime_environment: Optional[Dict[Any, Any]] = None
+        application_stack = attr.ib(type=Dict[Any, Any])
+        recommendation_type = attr.ib(type=str)
+        runtime_environment = attr.ib(type=Optional[Dict[Any, Any]], default=None)
 
         origin: Optional[str] = None
         github_event_type: Optional[str] = None
@@ -49,27 +50,10 @@ class AdviserReRunMessage(MessageBase):
         github_base_repo_url: Optional[str] = None
 
         source_type: Optional[str] = None
+        version: str = "v1"
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize adviser-re-run topic."""
         super(AdviserReRunMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/adviser_trigger.py
+++ b/thoth/messaging/adviser_trigger.py
@@ -31,10 +31,9 @@ _LOGGER = logging.getLogger(__name__)
 class AdviserTriggerMessage(MessageBase):
     """Class used for Advise events on Kafka topic."""
 
-    topic_name = "thoth.adviser-trigger"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.adviser-trigger"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents):  # type: ignore
         """Class used to represent contents of a message Kafka topic."""
 
         application_stack: Dict[Any, Any]
@@ -54,27 +53,10 @@ class AdviserTriggerMessage(MessageBase):
         github_base_repo_url: Optional[str] = None
         re_run_adviser_id: Optional[str] = None
         source_type: Optional[str] = None
+        version: str = "v1"
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self,):
         """Initialize advise-justification topic."""
         super(AdviserTriggerMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/config.py
+++ b/thoth/messaging/config.py
@@ -1,0 +1,28 @@
+import os
+
+confluent_config = {
+    "bootstrap.servers": ("KAFKA_BOOTSTRAP_SERVERS", str),
+    "client.id": ("KAFKA_CLIENT_ID", str),
+    "message.max.bytes": ("KAFKA_MESSAGE_MAX_BYTES", int),
+    "receive.message.max.bytes": ("KAFKA_RECEIVE_MESSAGE_MAX_BYTES", int),
+    "security.protocol": ("KAFKA_SECURITY_PROTOCOL", str),
+    "ssl.certificate.location": ("KAFKA_SSL_CERTIFICATE_LOCATION", str),
+    "ssl.endpoint.identification.algorithm": ("KAFKA_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM", str),
+    "sasl.mechanism": ("KAFKA_SASL_MECHANISM", str),
+    "sasl.username": ("KAFKA_SASL_USERNAME", str),
+    "sasl.password": ("KAFKA_SASL_PASSWORD", str),
+    "group.id": ("KAFKA_CONSUMER_GROUP_ID", str),
+    "group.instance.id": ("KAFKA_CONSUMER_GROUP_INSTANCE_ID", str),
+    "max.poll.interval.ms": ("KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS", float),
+    "enable.auto.commit": ("KAFKA_CONSUMER_ENABLE_AUTO_COMMIT", bool),
+}
+
+def kafka_config_from_env():
+    config = dict()
+    for k, v in confluent_config:
+        value = os.getenv(v[0], None)
+        if v:
+            if v[1] is bool:
+                config[k] = value.title() != "False"
+            else:
+                config[k] = v[1](value)

--- a/thoth/messaging/config.py
+++ b/thoth/messaging/config.py
@@ -1,5 +1,8 @@
 import os
 
+# For more configuration options go to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+# and add them to these dictionaries
+
 confluent_config = {
     "bootstrap.servers": ("KAFKA_BOOTSTRAP_SERVERS", str),
     "client.id": ("KAFKA_CLIENT_ID", str),
@@ -17,12 +20,32 @@ confluent_config = {
     "enable.auto.commit": ("KAFKA_CONSUMER_ENABLE_AUTO_COMMIT", bool),
 }
 
+topic_config = {
+    "compression.type": ("KAFKA_TOPIC_PRODUCER_COMPRESSION_TYPE", str),
+    "compression.level": ("KAFKA_TOPIC_PRODUCER_COMPRESSION_LEVEL", int),
+    "enable.auto.commit": ("KAFKA_TOPIC_CONSUMER_ENABLE_AUTO_COMMIT", bool),
+}
+
+
 def kafka_config_from_env():
     config = dict()
-    for k, v in confluent_config:
-        value = os.getenv(v[0], None)
-        if v:
-            if v[1] is bool:
+    for k in confluent_config:
+        value = os.getenv(confluent_config[k][0], None)
+        if value:
+            if confluent_config[k][1] is bool:
                 config[k] = value.title() != "False"
             else:
-                config[k] = v[1](value)
+                config[k] = confluent_config[k][1](value)
+    return config
+
+
+def topic_config_from_env():
+    config = dict()
+    for k in topic_config:
+        value = os.getenv(topic_config[k][0], None)
+        if value:
+            if topic_config[k][1] is bool:
+                config[k] = value.title() != "False"
+            else:
+                config[k] = topic_config[k][1](value)
+    return config

--- a/thoth/messaging/config.py
+++ b/thoth/messaging/config.py
@@ -1,3 +1,23 @@
+#!/usr/bin/env python3
+# thoth-messaging
+# Copyright(C) 2020 Kevin Postlethwait
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Helper functions for generating confluent kafka configuration."""
+
 import os
 
 # For more configuration options go to https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
@@ -28,6 +48,8 @@ topic_config = {
 
 
 def kafka_config_from_env():
+    """Generate Kafka configuration from environment variables."""
+    # NOTE: if a different config is desired please open an issue
     config = dict()
     for k in confluent_config:
         value = os.getenv(confluent_config[k][0], None)
@@ -40,6 +62,7 @@ def kafka_config_from_env():
 
 
 def topic_config_from_env():
+    """Generate topic config from environment variables."""
     config = dict()
     for k in topic_config:
         value = os.getenv(topic_config[k][0], None)

--- a/thoth/messaging/consumer.py
+++ b/thoth/messaging/consumer.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# thoth-messaging
+# Copyright(C) 2020 Kevin Postlethwait
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Helper functions for using confluent kafka consumer with thoth.messaging."""
+
+from typing import Optional, Dict
+
+from .config import kafka_config_from_env
+from .message_base import MessageBase
+from . import ALL_MESSAGES
+
+from confluent_kafka import Consumer
+
+
+def create_consumer(config: Optional[Dict[str, str]] = None) -> Consumer:
+    """Initialize consumer."""
+    if config:
+        return Consumer(config)
+    return Consumer(kafka_config_from_env())
+
+
+def subscribe_to_all(consumer: Consumer):
+    """Subscribe to all topics defined in messaging."""
+    to_subscribe = []
+    for i in ALL_MESSAGES:
+        to_subscribe.append(i().topic_name)
+
+    consumer.subscribe(to_subscribe)
+
+
+def subscribe_to_message(consumer: Consumer, message_type: MessageBase):
+    """Subscribe to specific message by passing message class."""
+    # NOTE: be sure to initialize message_type before passing
+    consumer.subscribe([message_type.topic_name])

--- a/thoth/messaging/hash_mismatch.py
+++ b/thoth/messaging/hash_mismatch.py
@@ -25,10 +25,9 @@ from typing import List
 class HashMismatchMessage(MessageBase):
     """Class used for Package Release events on Kafka topic."""
 
-    topic_name = "thoth.package-update.hash-mismatch"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.package-update.hash-mismatch"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents):
         """Class used to represent a contents of a hash-mismatch message Kafka topic."""
 
         index_url: str
@@ -36,27 +35,10 @@ class HashMismatchMessage(MessageBase):
         package_version: str
         missing_from_source: List[str]
         missing_from_database: List[str]
+        version: str = "v1"
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize hash mismatch topic."""
         super(HashMismatchMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/inspection_complete.py
+++ b/thoth/messaging/inspection_complete.py
@@ -24,35 +24,18 @@ from .message_base import MessageBase, BaseMessageContents
 class InspectionCompletedMessage(MessageBase):
     """Class used to indicate when amun inspections complete."""
 
-    topic_name = "thoth.inspection-completed"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.inspection-completed"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of a inspection-completed message Kafka topic."""
 
         inspection_id: str
         amun_api_url: str
         deployment_name: str
+        version: str = "v1"
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize package releases topic."""
         super(InspectionCompletedMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/kebechet_trigger.py
+++ b/thoth/messaging/kebechet_trigger.py
@@ -31,35 +31,17 @@ _LOGGER = logging.getLogger(__name__)
 class KebechetTriggerMessage(MessageBase):
     """Class used for Kebechet events on Kafka topic."""
 
-    topic_name = "thoth.kebechet-trigger"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.kebechet-trigger"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of a message Kafka topic."""
 
         webhook_payload: Dict[str, Any]
         job_id: Optional[str] = None
+        version: str = "v1"
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize advise-justification topic."""
         super(KebechetTriggerMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/message_base.py
+++ b/thoth/messaging/message_base.py
@@ -24,8 +24,6 @@ import logging
 import attr
 from typing import Optional
 
-from confluent_kafka import TopicPartition
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -49,6 +47,7 @@ class MessageBase:
 
     @property
     def topic_name(self):
+        """Generate topic name."""
         prefix = os.getenv("THOTH_DEPLOYMENT_NAME", None)
         if prefix is not None:
             return f"{prefix}.{self.base_name}"

--- a/thoth/messaging/message_factory.py
+++ b/thoth/messaging/message_factory.py
@@ -43,15 +43,7 @@ TYPE_SET = {
 
 
 def message_factory(
-    t_name: str,
-    message_contents: List[Tuple[str, str]],
-    num_partitions: int = 1,
-    replication_factor: int = 1,
-    client_id: str = "thoth-messaging",
-    ssl_auth: int = 1,
-    bootstrap_server: str = "localhost:9092",
-    topic_retention_time_second: int = 60 * 60 * 24 * 45,
-    protocol: str = "SSL",
+    b_name: str, message_contents: List[Tuple[str, str]],
 ):
     """Create new message types dynamically."""
     for i in message_contents:
@@ -61,9 +53,10 @@ def message_factory(
     class NewMessage(MessageBase):
         """Class used for any events on Kafka topic."""
 
-        base_name = t_name
+        base_name = b_name
         # we cannot have a message version for message factory so it will just default to v{message_base}.0
 
+        @attr.s
         class MessageContents(BaseMessageContents):
             """Class used to represent a contents of a faust message Kafka topic."""
 

--- a/thoth/messaging/missing_package.py
+++ b/thoth/messaging/missing_package.py
@@ -18,41 +18,26 @@
 
 """This is Thoth Messaging module for MissingPackageMessage."""
 
+import attr
+
 from .message_base import MessageBase, BaseMessageContents
 
 
 class MissingPackageMessage(MessageBase):
     """Class used for Package Release events on Kafka topic."""
 
-    topic_name = "thoth.package-update.missing-package"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.package-update.missing-package"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent a contents of a missing-package message Kafka topic."""
 
-        index_url: str
-        package_name: str
+        index_url = attr.ib(type=str)
+        package_name = attr.ib(type=str)
+        version = attr.ib(type=str, default="v1")
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize missing package topic."""
         super(MissingPackageMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/missing_version.py
+++ b/thoth/messaging/missing_version.py
@@ -18,6 +18,7 @@
 
 """This is Thoth Messaging module for MissingVersionMessage."""
 
+import attr
 
 from .message_base import MessageBase, BaseMessageContents
 
@@ -25,36 +26,19 @@ from .message_base import MessageBase, BaseMessageContents
 class MissingVersionMessage(MessageBase):
     """Class used for Package Release events on Kafka topic."""
 
-    topic_name = "thoth.package-update.missing-package-version"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.package-update.missing-package-version"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent a contents of a missing-package version message Kafka topic."""
 
-        index_url: str
-        package_name: str
-        package_version: str
+        index_url = attr.ib(type=str)
+        package_name = attr.ib(type=str)
+        package_version = attr.ib(type=str)
+        version = attr.ib(type=str, default="v1")
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize missing version topic."""
         super(MissingVersionMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/package_extract_trigger.py
+++ b/thoth/messaging/package_extract_trigger.py
@@ -19,6 +19,7 @@
 """This is Thoth Messaging module for PackageExtractTriggerMessage."""
 
 import logging
+import attr
 from typing import Optional
 
 from .message_base import MessageBase, BaseMessageContents
@@ -29,42 +30,25 @@ _LOGGER = logging.getLogger(__name__)
 class PackageExtractTriggerMessage(MessageBase):
     """Class used for Package Extract events on Kafka topic."""
 
-    topic_name = "thoth.package-extract-trigger"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.package-extract-trigger"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of a message Kafka topic."""
 
-        image: str
-        environment_type: str
-        is_external: bool = True
-        verify_tls: bool = True
-        debug: bool = False
-        job_id: Optional[str] = None
-        origin: Optional[str] = None
-        registry_user: Optional[str] = None
-        registry_password: Optional[str] = None
+        image = attr.ib(type=str)
+        environment_type = attr.ib(type=str)
+        is_external = attr.ib(type=bool, default=True)
+        verify_tls = attr.ib(type=bool, default=True)
+        debug = attr.ib(type=bool, default=False)
+        job_id = attr.ib(type=Optional[str], default=None)
+        origin = attr.ib(type=Optional[str], default=None)
+        registry_user = attr.ib(type=Optional[str], default=None)
+        registry_password = attr.ib(type=Optional[str], default=None)
+        version = attr.ib(type=str, default="v1", init=False)
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize advise-justification topic."""
         super(PackageExtractTriggerMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/package_releases.py
+++ b/thoth/messaging/package_releases.py
@@ -18,41 +18,28 @@
 
 """This is Thoth Messaging module for PackageReleasedMessage."""
 
+from typing import Optional
+import attr
+
 from .message_base import MessageBase, BaseMessageContents
 
 
 class PackageReleasedMessage(MessageBase):
     """Class used for Package Release events on Kafka topic."""
 
-    topic_name = "thoth.package-release.package-released"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.package-release.package-released"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of a package-released message Kafka topic."""
 
-        index_url: str
-        package_name: str
-        package_version: str
+        index_url = attr.ib(type=str)
+        package_name = attr.ib(type=str)
+        package_version = attr.ib(type=str)
+        version = attr.ib(type=str, default="v1", init=False)
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize package releases topic."""
         super(PackageReleasedMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/package_releases.py
+++ b/thoth/messaging/package_releases.py
@@ -18,7 +18,6 @@
 
 """This is Thoth Messaging module for PackageReleasedMessage."""
 
-from typing import Optional
 import attr
 
 from .message_base import MessageBase, BaseMessageContents

--- a/thoth/messaging/producer.py
+++ b/thoth/messaging/producer.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# thoth-messaging
+# Copyright(C) 2020 Kevin Postlethwait
+#
+# This program is free software: you can redistribute it and / or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Helper functions for using confluent kafka producer with thoth.messaging."""
+
+from attr import asdict
+from typing import Optional, Dict, Any
+from json import dumps
+import logging
+
+from .config import kafka_config_from_env
+from .message_base import MessageBase, BaseMessageContents
+
+from confluent_kafka import Producer
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def create_producer(config: Optional[Dict[str, Any]] = None):
+    """Create confluent kafka consumer."""
+    if config is not None:
+        return Producer(config)
+    return Producer(kafka_config_from_env())
+
+
+def publish_to_topic(producer: Producer, message_type: MessageBase, message_contents: BaseMessageContents):
+    """Publish to topic using message contents class."""
+    try:
+        producer.produce(message_type.topic_name, value=dumps(asdict(message_contents)).encode("utf-8"))
+    except Exception as e:
+        print(e)

--- a/thoth/messaging/provenance_checker_trigger.py
+++ b/thoth/messaging/provenance_checker_trigger.py
@@ -18,6 +18,7 @@
 
 """This is Thoth Messaging module for ProvenanceCheckerTriggerMessage."""
 
+import attr
 import logging
 from typing import Any
 from typing import Optional
@@ -32,38 +33,21 @@ _LOGGER = logging.getLogger(__name__)
 class ProvenanceCheckerTriggerMessage(MessageBase):
     """Class used for Provenance Checker events on Kafka topic."""
 
-    topic_name = "thoth.provenance-checker-trigger"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.provenance-checker-trigger"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of a message Kafka topic."""
 
-        application_stack: Dict[Any, Any]
-        debug: bool = False
-        origin: Optional[str] = None
-        whitelisted_sources: Optional[List[str]] = None
-        job_id: Optional[str] = None
+        application_stack = attr.ib(type=Dict[Any, Any])
+        debug = attr.ib(type=bool, default=False)
+        origin = attr.ib(type=Optional[str], default=None)
+        whitelisted_sources = attr.ib(type=Optional[List[str]], default=None)
+        job_id = attr.ib(type=Optional[str], default=None)
+        version = attr.ib(type=str, default="v1", init=False)
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize advise-justification topic."""
         super(ProvenanceCheckerTriggerMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/qebhwt_trigger.py
+++ b/thoth/messaging/qebhwt_trigger.py
@@ -18,6 +18,7 @@
 
 """This is Thoth Messaging module for QebHwtTriggerMessage."""
 
+import attr
 import logging
 from typing import Optional
 
@@ -29,42 +30,25 @@ _LOGGER = logging.getLogger(__name__)
 class QebHwtTriggerMessage(MessageBase):
     """Class used for QebHwt events on Kafka topic."""
 
-    topic_name = "thoth.qebhwt-trigger"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.qebhwt-trigger"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of a message Kafka topic."""
 
-        github_event_type: str
-        github_check_run_id: int
-        github_installation_id: int
-        github_base_repo_url: str
-        github_head_repo_url: str
-        origin: str
-        revision: str
-        host: str
-        job_id: Optional[str] = None
+        github_event_type = attr.ib(type=str)
+        github_check_run_id = attr.ib(type=int)
+        github_installation_id = attr.ib(type=int)
+        github_base_repo_url = attr.ib(type=str)
+        github_head_repo_url = attr.ib(type=str)
+        origin = attr.ib(type=str)
+        revision = attr.ib(type=str)
+        host = attr.ib(type=str)
+        job_id = attr.ib(type=Optional[str], default=None)
+        version = attr.ib(type=str, default="v1", init=False)
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize advise-justification topic."""
         super(QebHwtTriggerMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/si_unanalyzed_package.py
+++ b/thoth/messaging/si_unanalyzed_package.py
@@ -17,6 +17,7 @@
 
 """This is Thoth Messaging module for SIUnanalyzedPackageMessage."""
 
+import attr
 import logging
 
 from .message_base import MessageBase, BaseMessageContents
@@ -27,36 +28,19 @@ _LOGGER = logging.getLogger(__name__)
 class SIUnanalyzedPackageMessage(MessageBase):
     """Class used by Producer events on Kafka topic on packages not analyzed by SI."""
 
-    topic_name = "thoth.investigator.si-unanalyzed-package"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.investigator.si-unanalyzed-package"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of a SI unanalyzed package message Kafka topic."""
 
-        package_name: str
-        package_version: str
-        index_url: str
+        package_name = attr.ib(type=str)
+        package_version = attr.ib(type=str)
+        index_url = attr.ib(type=str)
+        version = attr.ib(type=str, default="v1", init=False)
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize si-unanalyzed-package topic."""
         super(SIUnanalyzedPackageMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/solved_package.py
+++ b/thoth/messaging/solved_package.py
@@ -18,6 +18,7 @@
 
 """This is Thoth Messaging module for SolvedPackageMessage."""
 
+import attr
 import logging
 
 from .message_base import MessageBase, BaseMessageContents
@@ -28,37 +29,20 @@ _LOGGER = logging.getLogger(__name__)
 class SolvedPackageMessage(MessageBase):
     """Class used for Solved Package events on Kafka topic."""
 
-    topic_name = "thoth.solver.solved-package"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.solver.solved-package"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of a solved package message Kafka topic."""
 
-        package_name: str
-        package_version: str
-        index_url: str
-        solver: str
+        package_name = attr.ib(type=str)
+        package_version = attr.ib(type=str)
+        index_url = attr.ib(type=str)
+        solver = attr.ib(type=str)
+        version = attr.ib(type=str, default="v1", init=False)
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize solved package topic."""
         super(SolvedPackageMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/unresolved_package.py
+++ b/thoth/messaging/unresolved_package.py
@@ -20,7 +20,7 @@
 
 import logging
 import attr
-from typing import Optional, List
+from typing import Optional
 
 from .message_base import MessageBase, BaseMessageContents
 
@@ -37,9 +37,9 @@ class UnresolvedPackageMessage(MessageBase):
         """Class used to represent contents of a unresolved package message Kafka topic."""
 
         package_name = attr.ib(type=str)
-        package_version = attr.ib(default=None, type=str)
-        index_url = attr.ib(default=None, type=str)
-        solver = attr.ib(default=None, type=str)
+        package_version = attr.ib(default=None, type=Optional[str])
+        index_url = attr.ib(default=None, type=Optional[str])
+        solver = attr.ib(default=None, type=Optional[str])
         version = attr.ib(type=str, default=None, init=False)
 
     def __init__(self):

--- a/thoth/messaging/unresolved_package.py
+++ b/thoth/messaging/unresolved_package.py
@@ -19,6 +19,7 @@
 """This is Thoth Messaging module for UnresolvedPackageMessage."""
 
 import logging
+import attr
 from typing import Optional, List
 
 from .message_base import MessageBase, BaseMessageContents
@@ -32,13 +33,14 @@ class UnresolvedPackageMessage(MessageBase):
     topic_name = "thoth.investigator.unresolved-package"
     _message_version = 1  # update on schema change
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of a unresolved package message Kafka topic."""
 
-        package_name: str
-        package_version: Optional[str]
-        index_url: Optional[List[str]]
-        solver: Optional[str]
+        package_name = attr.ib(type=str)
+        package_version = attr.ib(default=None, type=str)
+        index_url = attr.ib(default=None, type=str)
+        solver = attr.ib(default=None, type=str)
 
     def __init__(
         self,

--- a/thoth/messaging/unresolved_package.py
+++ b/thoth/messaging/unresolved_package.py
@@ -30,8 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 class UnresolvedPackageMessage(MessageBase):
     """Class used by Investigator producer events on Kafka topic."""
 
-    topic_name = "thoth.investigator.unresolved-package"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.investigator.unresolved-package"
 
     @attr.s
     class MessageContents(BaseMessageContents):
@@ -41,27 +40,10 @@ class UnresolvedPackageMessage(MessageBase):
         package_version = attr.ib(default=None, type=str)
         index_url = attr.ib(default=None, type=str)
         solver = attr.ib(default=None, type=str)
+        version = attr.ib(type=str, default=None, init=False)
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize unresolved package topic."""
         super(UnresolvedPackageMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/unrevsolved_package.py
+++ b/thoth/messaging/unrevsolved_package.py
@@ -17,6 +17,7 @@
 
 """This is Thoth Messaging module for UnrevsolvedPackageMessage."""
 
+import attr
 import logging
 
 from .message_base import MessageBase, BaseMessageContents
@@ -27,35 +28,18 @@ _LOGGER = logging.getLogger(__name__)
 class UnrevsolvedPackageMessage(MessageBase):
     """Class used by Producer events on Kafka topic on Reverse Solver events."""
 
-    topic_name = "thoth.investigator.unrevsolved-package"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.investigator.unrevsolved-package"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent contents of a unrevsolved package message Kafka topic."""
 
-        package_name: str
-        package_version: str
+        package_name = attr.ib(type=str)
+        package_version = attr.ib(type=str)
+        version = attr.ib(type=str, default="v1", init=False)
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize unrevsolved package topic."""
         super(UnrevsolvedPackageMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )

--- a/thoth/messaging/update_provides_src_distro.py
+++ b/thoth/messaging/update_provides_src_distro.py
@@ -18,43 +18,31 @@
 
 """This is Thoth Messaging module for UpdateProvidesSourceDistroMessage."""
 
+import attr
+import logging
+
 from .message_base import MessageBase, BaseMessageContents
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class UpdateProvidesSourceDistroMessage(MessageBase):
     """Class used for updating python package version provides_source_distro flag."""
 
-    topic_name = "thoth.update-provides-source-distro"
-    _message_version = 1  # update on schema change
+    base_name = "thoth.update-provides-source-distro"
 
-    class MessageContents(BaseMessageContents, serializer="json"):  # type: ignore
+    @attr.s
+    class MessageContents(BaseMessageContents):
         """Class used to represent a contents of a update-provides-source-distro message."""
 
-        package_name: str
-        package_version: str
-        index_url: str
-        value: bool
+        package_name = attr.ib(type=str)
+        package_version = attr.ib(type=str)
+        index_url = attr.ib(type=str)
+        value = attr.ib(type=bool)
+        version = attr.ib(type=str, default="v1", init=False)
 
-    def __init__(
-        self,
-        num_partitions: int = 1,
-        replication_factor: int = 1,
-        client_id: str = "thoth-messaging",
-        ssl_auth: int = 1,
-        bootstrap_server: str = "localhost:9092",
-        topic_retention_time_second: int = 60 * 60 * 24 * 45,
-        protocol: str = "SSL",
-    ):
+    def __init__(self):
         """Initialize missing package topic."""
         super(UpdateProvidesSourceDistroMessage, self).__init__(
-            topic_name=self.topic_name,
-            value_type=self.MessageContents,
-            num_partitions=num_partitions,
-            replication_factor=replication_factor,
-            client_id=client_id,
-            ssl_auth=ssl_auth,
-            bootstrap_server=bootstrap_server,
-            topic_retention_time_second=topic_retention_time_second,
-            protocol=protocol,
-            message_version=self._message_version,
+            base_name=self.base_name, value_type=self.MessageContents,
         )


### PR DESCRIPTION
## Related Issues and Dependencies

This is related to the issue with Faust where we stopped consuming messages.

## This introduces a breaking change

- [x] Yes
- [ ] No

## This should yield a new module release

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

This change is incompatible with `Faust` and changes names of env variables for configuration.

## This Pull Request implements

Removes reliance on `Faust` and moves to more stable library called `confluent-kakfa`

## Description

All configuration information is now present in confluent kakfa producers.  We do not need to worry about when an app starts because confluent producers and consumers can be explicitly created.  This change removes the `Faust` framework, and should allow for more complexity/flexibility when it comes to creating producers and consumers.