### PR TITLE
change message contents of inspection complete

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 - [ ] Yes
 - [ ] No
 
-## Has a Message Class been changed? Version incremented? 
+## Has a Message Class been changed? Version incremented?
 
 - [ ] Yes
 - [ ] No

--- a/thoth/messaging/inspection_complete.py
+++ b/thoth/messaging/inspection_complete.py
@@ -33,8 +33,7 @@ class InspectionCompletedMessage(MessageBase):
         """Class used to represent contents of a inspection-completed message Kafka topic."""
 
         inspection_id = attr.ib(type=str)
-        amun_api_url = attr.ib(type=str)
-        deployment_name = attr.ib(type=str)
+        force_sync = attr.ib(type=bool)
         version = attr.ib(type=str, default="v1", init=False)
 
     def __init__(self):


### PR DESCRIPTION
## Related Issues and Dependencies

https://github.com/thoth-station/thoth-application/issues/398

## This introduces a breaking change

- [ ] Yes
- [x] No

## Has a Message Class been changed? Version incremented? 

- [x] Yes
- [ ] No


## This should yield a new module release

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

I lost track of this issue and was working through it again and the original message contents that I established don't make sense with the requirements on investigator side. This does not require a new version of the message as it hasn't been produced at all yet.

Current KPostOffice: :brain: 
Past KPostOffice: :man_facepalming: 
