### PR TITLE
add metadata to kebechet-run-url

### DIFF
--- a/thoth/messaging/kebechet_run_url.py
+++ b/thoth/messaging/kebechet_run_url.py
@@ -27,6 +27,13 @@ from .message_base import MessageBase, BaseMessageContents
 _LOGGER = logging.getLogger(__name__)
 
 
+@attr.s
+class Metadata:
+    """Metadata for kebechet-run-url message type."""
+
+    message_justification = attr.ib(type=Optional[int], default=None)
+
+
 class KebechetRunUrlTriggerMessage(MessageBase):
     """Class used for Kebechet Run Url events on Kafka topic."""
 
@@ -40,7 +47,8 @@ class KebechetRunUrlTriggerMessage(MessageBase):
         service_name = attr.ib(type=Optional[str], default=None)
         installation_id = attr.ib(type=Optional[str], default=None)
         job_id = attr.ib(type=Optional[str], default=None)
-        version = attr.ib(type=str, default="v1", init=False)
+        metadata = attr.ib(type=Metadata, default=Metadata())
+        version = attr.ib(type=str, default="v2", init=False)
 
     def __init__(self):
         """Initialize kebechet-run-url topic."""


### PR DESCRIPTION
## Related Issues and Dependencies

thoth-station/kebechet#584

## This introduces a breaking change

- [ ] Yes
- [x] No

## Has a Message Class been changed? Version incremented?

- [x] Yes
- [ ] No


## This should yield a new module release

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

This is a way of implementing metadata to be nested while still enforcing strict message contents

One alternative might be:
https://github.com/Julian/jsonschema
