### PR TITLE
update pre-commit to use py38

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,5 +1,5 @@
 check:
-  - thoth-precommit
+  - thoth-precommit-py38
   - thoth-build
 release:
   - upload-pypi-sesheta


### PR DESCRIPTION
## Related Issues and Dependencies

#348 is failing because py3.8 adds TypedDicts to the typing library
