### PR TITLE
Add authenticated parameter to the advise-triggering message

### DIFF
--- a/thoth/messaging/adviser_trigger.py
+++ b/thoth/messaging/adviser_trigger.py
@@ -39,6 +39,7 @@ class AdviserTriggerMessage(MessageBase):
         recommendation_type = attr.ib(type=str)
         dev = attr.ib(type=bool, default=False)
         debug = attr.ib(type=bool, default=False)
+        authenticated = attr.ib(type=bool, default=False)
         count = attr.ib(type=Optional[int], default=None)
         limit = attr.ib(type=Optional[int], default=None)
         origin = attr.ib(type=Optional[str], default=None)
@@ -53,7 +54,7 @@ class AdviserTriggerMessage(MessageBase):
         kebechet_metadata = attr.ib(type=Optional[Dict[str, Any]], default=None)
         justification = attr.ib(type=Optional[List[Dict[str, Any]]], default=None)
         stack_info = attr.ib(type=Optional[List[Dict[str, Any]]], default=None)
-        version = attr.ib(type=str, default="v3", init=False)
+        version = attr.ib(type=str, default="v4", init=False)
 
     def __init__(self,):
         """Initialize advise-justification topic."""


### PR DESCRIPTION
## Related Issues and Dependencies

Related: https://github.com/thoth-station/common/pull/1146

## This introduces a breaking change

- [x] No

## Has a Message Class been changed? Version incremented?

- [x] Yes

## This should yield a new module release

- [x] Yes
