### PR TITLE
all message senders pass index url explicitly

### DIFF
--- a/thoth/messaging/unresolved_package.py
+++ b/thoth/messaging/unresolved_package.py
@@ -35,8 +35,8 @@ class MessageContents(BaseMessageContents):
     """Class used to represent contents of a unresolved package message Kafka topic."""
 
     package_name: StrictStr
+    index_url: StrictStr
     package_version: Optional[StrictStr]
-    index_url: Optional[StrictStr]
     solver: Optional[StrictStr]
     version: StrictStr = "v1"
 


### PR DESCRIPTION
## Related Issues and Dependencies

index is not actually optional. We want to explicitly specify which indexes are being scheduled by unresolved package messages