### PR TITLE
updating pre-commit protocol and aicoe build-strategy

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -4,7 +4,7 @@ release:
   - upload-pypi-sesheta
 build:
   base-image: quay.io/thoth-station/s2i-thoth-ubi8-py38:v0.20.1
-  build-stratergy: Source
+  build-strategy: Source
   registry: quay.io
   registry-org: thoth-station
   registry-project: messaging

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 
 ---
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.7
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0
     hooks:
       - id: trailing-whitespace
@@ -23,7 +23,7 @@ repos:
       - id: check-ast
       - id: debug-statements
 
-  - repo: git://github.com/pycqa/pydocstyle.git
+  - repo: https://github.com/pycqa/pydocstyle.git
     rev: 5.0.2
     hooks:
       - id: pydocstyle


### PR DESCRIPTION
Using unencrypted version of the git protocol has been deprecated. Switching to HTTPS for pre-commit repos. Additionally fixing 'build-stratergy' in '.aicoe-ci.yaml'

## Related Issues and Dependencies

https://github.com/thoth-station/thoth-application/issues/2111