### PR TITLE
Enable auto offset reset for kafka consumer

### DIFF
--- a/thoth/messaging/config.py
+++ b/thoth/messaging/config.py
@@ -41,6 +41,7 @@ confluent_config = {
     "group.instance.id": ("KAFKA_CONSUMER_GROUP_INSTANCE_ID", str),
     "max.poll.interval.ms": ("KAFKA_CONSUMER_MAX_POLL_INTERVAL_MS", float),
     "enable.auto.commit": ("KAFKA_CONSUMER_ENABLE_AUTO_COMMIT", bool),
+    "auto.offset.reset": ("KAFKA_CONSUMER_AUTO_OFFSET_RESET", str),
 }
 
 topic_config = {


### PR DESCRIPTION
Enable auto offset reset for kafka consumer
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/thoth-application/issues/2566

## Description

Some topics offset have been hindered 
This would help resolve our kafka consumer pause. 
Reference: https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#consumerconfigs_auto.offset.reset